### PR TITLE
Making the Open PRs, issues, stars and security alerts clickable

### DIFF
--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/types/samples.ts
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/types/samples.ts
@@ -9,6 +9,7 @@ export interface ISampleItem {
     pullRequests: any;
     issues: any;
     stargazers: any;
+    url: string;
     featureArea: string;
     vulnerabilityAlerts: any;
 }

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
@@ -76,7 +76,6 @@ export default class Samples extends React.Component<{}, ISamplesState> {
         const response = await fetch('api/samples');
         const data = await response.json();
         this.allItems = data;
-        console.log(data);
         this.setState(
             {
                 items: this.allItems,

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
@@ -53,7 +53,7 @@ export default class Samples extends React.Component<{}, ISamplesState> {
                 isResizable: true, onColumnClick: this.onColumnClick },
             { key: 'starsCount', name: 'Stars', fieldName: 'totalCount', minWidth: 100, maxWidth: 100, 
                 isResizable: true, onColumnClick: this.onColumnClick },
-            { key: 'featureArea', name: 'Feature Area', fieldName: 'featureArea', minWidth: 100, maxWidth: 200, 
+            { key: 'featureArea', name: 'Feature Area', fieldName: 'featureArea', minWidth: 200, maxWidth: 300, 
                 isResizable: true, onColumnClick: this.onColumnClick },
             { key: 'vulnerabilityAlertsCount', name: 'Security Alerts', fieldName: 'totalCount', 
                 minWidth: 100, maxWidth: 100, isResizable: true, onColumnClick: this.onColumnClick }
@@ -76,6 +76,7 @@ export default class Samples extends React.Component<{}, ISamplesState> {
         const response = await fetch('api/samples');
         const data = await response.json();
         this.allItems = data;
+        console.log(data);
         this.setState(
             {
                 items: this.allItems,
@@ -155,6 +156,7 @@ function renderItemColumn(item: ISampleItem, index: number | undefined, column: 
     const pullRequestCount = item.pullRequests.totalCount;
     const issueCount = item.issues.totalCount;
     const starsCount = item.stargazers.totalCount;
+    const url = item.url;
     const featureArea = item.featureArea;
     const vulnerabilityAlertsCount = item.vulnerabilityAlerts.totalCount;
 
@@ -163,7 +165,7 @@ function renderItemColumn(item: ISampleItem, index: number | undefined, column: 
             return <div>
                 <Link to={`/samples/${sampleName}`} ><span>{sampleName} </ span></Link>
             </div>;
-
+        
         case 'Owner':
             return <span>{owner} </span>;
 
@@ -174,18 +176,21 @@ function renderItemColumn(item: ISampleItem, index: number | undefined, column: 
             return <span>{language}</span>;
 
         case 'Open Pull Requests':
-            return <span>{pullRequestCount} </span>;
+            return <a href={`${url}/pulls`} target="_blank"> <span>{pullRequestCount} </span></a>
 
         case 'Open Issues':
-            return <span>{issueCount}</span>;
+            return <a href={`${url}/issues`} target="_blank"> <span>{issueCount}</span></a>
 
         case 'Stars':
-            return <span>{starsCount} </span>;
+            return <a href={`${url}`} target="_blank"> <span>{starsCount} </span></a>;
 
         case 'Feature Area':
             return <span> {featureArea} </span>;
 
         case 'Security Alerts':
+            if (vulnerabilityAlertsCount > 0) {
+                return <a href={`${url}/network/alerts`} target="_blank"> <span>{vulnerabilityAlertsCount} </span></a>;
+            }
             return <span>{vulnerabilityAlertsCount} </span>;
 
     }

--- a/SamplesDashboard/SamplesDashboard/Models/SampleQueries.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/SampleQueries.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------
 
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace SamplesDashboard
@@ -46,6 +47,8 @@ namespace SamplesDashboard
 
         [JsonProperty("stargazers")]
         public Issues Stargazers { get; set; }
+        [JsonProperty("url")]
+        public Uri Url { get; set; }
         public string Language { get; internal set; }
         public string FeatureArea { get; internal set; }
     }

--- a/SamplesDashboard/SamplesDashboard/Services/SampleService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/SampleService.cs
@@ -59,6 +59,7 @@ namespace SamplesDashboard.Services
                                     stargazers {
                                         totalCount
                                     }
+                                    url
                                 }
                             }
                         }

--- a/SamplesDashboard/SamplesDashboardTests/SampleServiceTests.cs
+++ b/SamplesDashboard/SamplesDashboardTests/SampleServiceTests.cs
@@ -72,7 +72,7 @@ namespace SamplesDashboardTests
             Assert.True(headerDetails["services"] == "Office 365,Users");
             _helper.WriteLine(string.Join("\n", headerDetails));
 
-        }
+        }       
     }
 }
  


### PR DESCRIPTION
## Description
Making the open issues, open pull requests, stars and security alerts open to the specific github pages on a different tab.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


#### Closing issue
Fixes #49 
Fixes #17 
