### PR TITLE
Hiding the Security Alerts Column

### DIFF
--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Home.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Home.tsx
@@ -5,7 +5,7 @@ class Home extends Component {
     public render() {
         return (
             <div>
-                <Samples />
+                <Samples isAuthenticated={false} />
             </div>
         );
     }

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
@@ -1,5 +1,5 @@
 ﻿import {  DetailsListLayoutMode, IColumn,
-    SelectionMode, ShimmeredDetailsList } from 'office-ui-fabric-react';
+    SelectionMode, ShimmeredDetailsList, FontIcon } from 'office-ui-fabric-react';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
 import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
@@ -28,7 +28,12 @@ const classNames = mergeStyleSets({
     },
     pageTitle: {
         fontSize: FontSizes.large
-    }
+    },
+    yellow: {
+        color: '#ffaa44',
+        marginRight: '5px'
+    },
+    red: { color: '#d13438' }
 });
 
 export default class Samples extends React.Component<{}, ISamplesState> {
@@ -181,14 +186,14 @@ function renderItemColumn(item: ISampleItem, index: number | undefined, column: 
             return <a href={`${url}/issues`} target="_blank"> <span>{issueCount}</span></a>
 
         case 'Stars':
-            return <a href={`${url}`} target="_blank"> <span>{starsCount} </span></a>;
+            return <a href={`${url}`} target="_blank"> <FontIcon iconName="FavoriteStarFill" className={classNames.yellow} /><span>{starsCount} </span></a>;
 
         case 'Feature Area':
             return <span> {featureArea} </span>;
 
         case 'Security Alerts':
             if (vulnerabilityAlertsCount > 0) {
-                return <a href={`${url}/network/alerts`} target="_blank"> <span>{vulnerabilityAlertsCount} </span></a>;
+                return <a href={`${url}/network/alerts`} target="_blank"> <FontIcon iconName="StatusErrorFull" className={classNames.red} /> <span>{vulnerabilityAlertsCount} </span></a>;
             }
             return <span>{vulnerabilityAlertsCount} </span>;
 

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
@@ -33,7 +33,6 @@ const classNames = mergeStyleSets({
         color: '#ffaa44',
         marginRight: '5px'
     }
-    red: { color: '#d13438' }
 });
 
 export default class Samples extends React.Component<{ isAuthenticated: boolean }, ISamplesState> {
@@ -59,9 +58,7 @@ export default class Samples extends React.Component<{ isAuthenticated: boolean 
             { key: 'starsCount', name: 'Stars', fieldName: 'totalCount', minWidth: 100, maxWidth: 100, 
                 isResizable: true, onColumnClick: this.onColumnClick },
             { key: 'featureArea', name: 'Feature Area', fieldName: 'featureArea', minWidth: 200, maxWidth: 300, 
-                isResizable: true, onColumnClick: this.onColumnClick },
-            { key: 'vulnerabilityAlertsCount', name: 'Security Alerts', fieldName: 'totalCount', 
-                minWidth: 100, maxWidth: 100, isResizable: true, onColumnClick: this.onColumnClick }
+                isResizable: true, onColumnClick: this.onColumnClick }
         ];
 
         if (this.props.isAuthenticated) {

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
@@ -1,4 +1,4 @@
-﻿import {  DetailsListLayoutMode, IColumn,
+import {  DetailsListLayoutMode, IColumn,
     SelectionMode, ShimmeredDetailsList, FontIcon } from 'office-ui-fabric-react';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
@@ -32,14 +32,14 @@ const classNames = mergeStyleSets({
     yellow: {
         color: '#ffaa44',
         marginRight: '5px'
-    },
+    }
     red: { color: '#d13438' }
 });
 
-export default class Samples extends React.Component<{}, ISamplesState> {
+export default class Samples extends React.Component<{ isAuthenticated: boolean }, ISamplesState> {
     private allItems: ISampleItem[];
 
-    constructor(props: {}) {
+    constructor(props: { isAuthenticated: boolean }) {
         super(props);
 
         this.allItems = [];
@@ -63,6 +63,13 @@ export default class Samples extends React.Component<{}, ISamplesState> {
             { key: 'vulnerabilityAlertsCount', name: 'Security Alerts', fieldName: 'totalCount', 
                 minWidth: 100, maxWidth: 100, isResizable: true, onColumnClick: this.onColumnClick }
         ];
+
+        if (this.props.isAuthenticated) {
+            columns.push({
+                key: 'vulnerabilityAlertsCount', name: 'Security Alerts', fieldName: 'totalCount',
+                minWidth: 100, maxWidth: 100, isResizable: true, onColumnClick: this.onColumnClick
+            });
+        }
 
         this.state = {
             columns,
@@ -193,7 +200,8 @@ function renderItemColumn(item: ISampleItem, index: number | undefined, column: 
 
         case 'Security Alerts':
             if (vulnerabilityAlertsCount > 0) {
-                return <a href={`${url}/network/alerts`} target="_blank"> <FontIcon iconName="StatusErrorFull" className={classNames.red} /> <span>{vulnerabilityAlertsCount} </span></a>;
+                return <a href={`${url}/network/alerts`} target="_blank">
+                    <FontIcon iconName="WarningSolid" className={classNames.yellow} /> <span>{vulnerabilityAlertsCount} </span></a>;
             }
             return <span>{vulnerabilityAlertsCount} </span>;
 

--- a/SamplesDashboard/SamplesDashboard/Services/SampleService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/SampleService.cs
@@ -139,17 +139,17 @@ namespace SamplesDashboard.Services
         }
 
         /// <summary>
-        /// 
+        /// Gets the repository's details and updates the status field in the dependencies
         /// </summary>
-        /// <param name="repository"></param>
-        /// <returns></returns>
+        /// <param name="repository"> A Repository object</param>
+        /// <returns>An updated repository object with the status field.</returns>
         private Repository UpdateRepositoryStatus(Repository repository)
         {
             var dependencyGraphManifests = repository?.DependencyGraphManifests?.Nodes;
             if (dependencyGraphManifests == null) 
                 return repository;
             
-            // Go throught the various dependency manifests in the repo
+            // Go through the various dependency manifests in the repo
             foreach (var dependencyManifest in dependencyGraphManifests)
             {
                 var dependencies = dependencyManifest?.Dependencies?.Nodes;
@@ -169,7 +169,7 @@ namespace SamplesDashboard.Services
             return repository;
         }
         /// <summary>
-        /// Calulate the status of a sample
+        /// Calculate the status of a sample
         /// </summary>
         /// <param name="sampleVersion">The current version of thr sample</param>
         /// <param name="latestVersion">The latest version of the sample</param>
@@ -179,6 +179,7 @@ namespace SamplesDashboard.Services
             if (string.IsNullOrEmpty(sampleVersion) || string.IsNullOrEmpty(latestVersion))
                 return PackageStatus.Unknown;
 
+            // Dropping any 'v's that occur before the version
             if (sampleVersion.StartsWith("v"))
             {
                 sampleVersion = sampleVersion.Substring(1);


### PR DESCRIPTION
## Description

Hiding the security alerts column by using an isAuthitcated prop to determine if the column can be displayed. 

Preview:
![image](https://user-images.githubusercontent.com/18407044/75868723-8a8e5b00-5e19-11ea-8fe2-a3536ea5d289.png)

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Closing issue
Fixes #50 
