### PR TITLE
Fix sorting bug

### DIFF
--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/components/layout/NavMenu.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/components/layout/NavMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Collapse, Container, Navbar, NavbarBrand, NavbarToggler, NavItem, NavLink } from 'reactstrap';
+import { Collapse, Container, Navbar, NavbarBrand, NavbarToggler } from 'reactstrap';
 import './NavMenu.css';
 
 export default class NavMenu extends React.PureComponent<{}, { isOpen: boolean }> {
@@ -16,11 +16,6 @@ export default class NavMenu extends React.PureComponent<{}, { isOpen: boolean }
                         <NavbarBrand tag={Link} to='/'>Samples Dashboard</NavbarBrand>
                         <NavbarToggler onClick={this.toggle} className='mr-2'/>
                         <Collapse className='d-sm-inline-flex flex-sm-row-reverse' isOpen={this.state.isOpen} navbar>
-                            <ul className='navbar-nav flex-grow'>
-                                <NavItem>
-                                    <NavLink tag={Link} className='text-dark' to='/'>Home</NavLink>
-                                </NavItem>
-                            </ul>
                         </Collapse>
                     </Container>
                 </Navbar>

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/custom.css
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/custom.css
@@ -24,3 +24,6 @@ td, th {
 .container {
     max-width: 100%
 }
+.ms-Viewport {
+    padding-right: 10px;
+}

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Details.tsx
@@ -74,10 +74,10 @@ export default class Details extends React.Component<any, any> {
         return (
             <Fabric>
                 <div>
-                    <PageTitle title={repositoryDetails.name} />
+                    <PageTitle title={`List of libraries in ${repositoryDetails.name}`} />
                     { isLoading ?
                         <div /> :
-                        <PrimaryButton href={repositoryDetails.url} target="_blank" > <FontIcon iconName="OpenInNewTab" className={iconClass} /> Go to Repository </PrimaryButton> 
+                        <PrimaryButton href={repositoryDetails.url} target="_blank" rel="noopener noreferrer"> <FontIcon iconName="OpenInNewTab" className={iconClass} /> Go to Repository </PrimaryButton> 
                     }
                     <ShimmeredDetailsList
                         items={items}
@@ -92,6 +92,8 @@ export default class Details extends React.Component<any, any> {
             </Fabric>
         );
     }
+
+
 }
 
 function renderItemColumn(item: IDetailsItem, index: number | undefined, column: IColumn | undefined) {

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
@@ -1,5 +1,7 @@
-import {  DetailsListLayoutMode, IColumn,
-    SelectionMode, ShimmeredDetailsList, FontIcon } from 'office-ui-fabric-react';
+import {
+    DetailsListLayoutMode, IColumn,
+    SelectionMode, ShimmeredDetailsList, FontIcon
+} from 'office-ui-fabric-react';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
 import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
@@ -43,27 +45,43 @@ export default class Samples extends React.Component<{ isAuthenticated: boolean 
 
         this.allItems = [];
         const columns: IColumn[] = [
-            { key: 'name', name: 'Name', fieldName: 'name', minWidth: 200, maxWidth: 300, isRowHeader: true, 
-                isResizable: true, isSorted: true, isSortedDescending: false, onColumnClick: this.onColumnClick },
-            { key: 'login', name: 'Owner', fieldName: 'login', minWidth: 100, maxWidth: 150, 
-                isResizable: true, onColumnClick: this.onColumnClick },
-            { key: 'status', name: 'Status', fieldName: 'status', minWidth: 100, maxWidth: 150, 
-                isResizable: true, onColumnClick: this.onColumnClick },
-            { key: 'language', name: 'Language', fieldName: 'language', minWidth: 100, maxWidth: 150, 
-                isResizable: true, onColumnClick: this.onColumnClick },
-            { key: 'pullRequestCount', name: 'Open Pull Requests', fieldName: 'totalCount', minWidth: 100, 
-                maxWidth: 150, isResizable: true, onColumnClick: this.onColumnClick },
-            { key: 'issueCount', name: 'Open Issues', fieldName: 'totalCount', minWidth: 100, maxWidth: 150, 
-                isResizable: true, onColumnClick: this.onColumnClick },
-            { key: 'starsCount', name: 'Stars', fieldName: 'totalCount', minWidth: 100, maxWidth: 100, 
-                isResizable: true, onColumnClick: this.onColumnClick },
-            { key: 'featureArea', name: 'Feature Area', fieldName: 'featureArea', minWidth: 200, maxWidth: 300, 
-                isResizable: true, onColumnClick: this.onColumnClick }
+            {
+                key: 'name', name: 'Name', fieldName: 'name', minWidth: 200, maxWidth: 300, isRowHeader: true,
+                isResizable: true, isSorted: true, isSortedDescending: false, onColumnClick: this.onColumnClick
+            },
+            {
+                key: 'login', name: 'Owner', fieldName: 'login', minWidth: 100, maxWidth: 150,
+                isResizable: true, onColumnClick: this.onColumnClick
+            },
+            {
+                key: 'status', name: 'Status', fieldName: 'status', minWidth: 100, maxWidth: 150,
+                isResizable: true, onColumnClick: this.onColumnClick
+            },
+            {
+                key: 'language', name: 'Language', fieldName: 'language', minWidth: 100, maxWidth: 150,
+                isResizable: true, onColumnClick: this.onColumnClick
+            },
+            {
+                key: 'pullRequestCount', name: 'Open Pull Requests', fieldName: 'pullRequests', minWidth: 100,
+                maxWidth: 150, isResizable: true, onColumnClick: this.onColumnClick
+            },
+            {
+                key: 'issueCount', name: 'Open Issues', fieldName: 'issues', minWidth: 100, maxWidth: 150,
+                isResizable: true, onColumnClick: this.onColumnClick
+            },
+            {
+                key: 'starsCount', name: 'Stars', fieldName: 'stargazers', minWidth: 100, maxWidth: 100,
+                isResizable: true, onColumnClick: this.onColumnClick
+            },
+            {
+                key: 'featureArea', name: 'Feature Area', fieldName: 'featureArea', minWidth: 200, maxWidth: 300,
+                isResizable: true, onColumnClick: this.onColumnClick
+            }
         ];
 
         if (this.props.isAuthenticated) {
             columns.push({
-                key: 'vulnerabilityAlertsCount', name: 'Security Alerts', fieldName: 'totalCount',
+                key: 'vulnerabilityAlertsCount', name: 'Security Alerts', fieldName: 'vulnerabilityAlerts',
                 minWidth: 100, maxWidth: 100, isResizable: true, onColumnClick: this.onColumnClick
             });
         }
@@ -108,15 +126,15 @@ export default class Samples extends React.Component<{ isAuthenticated: boolean 
                                 styles={{ root: { maxWidth: '300px' } }}
                             />
                         </Sticky>
-                            <ShimmeredDetailsList
-                                items={items}
-                                columns={columns}
-                                selectionMode={SelectionMode.none}
-                                layoutMode={DetailsListLayoutMode.justified}
-                                isHeaderVisible={true}
-                                onRenderItemColumn={renderItemColumn}
-                                enableShimmer={isLoading}
-                            />
+                        <ShimmeredDetailsList
+                            items={items}
+                            columns={columns}
+                            selectionMode={SelectionMode.none}
+                            layoutMode={DetailsListLayoutMode.justified}
+                            isHeaderVisible={true}
+                            onRenderItemColumn={renderItemColumn}
+                            enableShimmer={isLoading}
+                        />
                     </ScrollablePane>
                 </div>
             </Fabric>
@@ -130,7 +148,7 @@ export default class Samples extends React.Component<{ isAuthenticated: boolean 
     private onFilterName = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text?: string | undefined): void => {
         this.setState({
             items: text ? this.allItems.filter(i => i.name.toLowerCase().indexOf(text) > -1) : this.allItems
-            });
+        });
     };
 
     private onColumnClick = (ev: React.MouseEvent<HTMLElement>, column: IColumn): void => {
@@ -157,7 +175,7 @@ export default class Samples extends React.Component<{ isAuthenticated: boolean 
 // rendering the language and service component within the details list
 function renderItemColumn(item: ISampleItem, index: number | undefined, column: IColumn | undefined) {
     const col = column as IColumn;
-    const sampleName = item.name;   
+    const sampleName = item.name;
     const owner = item.owner.login;
     const status = item.status;
     const language = item.language;
@@ -173,7 +191,7 @@ function renderItemColumn(item: ISampleItem, index: number | undefined, column: 
             return <div>
                 <Link to={`/samples/${sampleName}`} ><span>{sampleName} </ span></Link>
             </div>;
-        
+
         case 'Owner':
             return <span>{owner} </span>;
 
@@ -206,5 +224,39 @@ function renderItemColumn(item: ISampleItem, index: number | undefined, column: 
 }
 function copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
     const key = columnKey as keyof T;
-    return items.slice(0).sort((a: T, b: T) => ((isSortedDescending ? a[key] < b[key] : a[key] > b[key]) ? 1 : -1));
+    let itemsSorted = items.slice(0).sort((a: T, b: T) => (compare(a[key], b[key], isSortedDescending)));
+    return itemsSorted;
+}
+
+function compare(a: any, b: any, isSortedDescending?: boolean) {
+    // Handle the possible scenario of blank inputs 
+    // and keep them at the bottom of the lists
+    if (!a) return 1;
+    if (!b) return -1;
+
+    let valueA: any;
+    let valueB: any;
+    let comparison = 0;
+
+    if (typeof a === 'string' || a instanceof String) {
+        // Use toUpperCase() to ignore character casing
+        valueA = a.toUpperCase();
+        valueB = b.toUpperCase();;
+    } else {
+        // its an object which has a totalCount property
+        valueA = a.totalCount;
+        valueB = b.totalCount;
+    }
+
+    if (valueA > valueB) {
+        comparison = 1;
+    } else if (valueA < valueB) {
+        comparison = -1;
+    }
+
+    if (isSortedDescending) {
+        comparison = comparison * -1;
+    }
+
+    return comparison;
 }

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Samples.tsx
@@ -1,6 +1,6 @@
 import {
     DetailsListLayoutMode, IColumn,
-    SelectionMode, ShimmeredDetailsList, FontIcon
+    SelectionMode, ShimmeredDetailsList, FontIcon, IRenderFunction, IDetailsHeaderProps, IDetailsColumnRenderTooltipProps, TooltipHost
 } from 'office-ui-fabric-react';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
@@ -33,7 +33,7 @@ const classNames = mergeStyleSets({
     },
     yellow: {
         color: '#ffaa44',
-        marginRight: '5px'
+        paddingRight: '5px'
     }
 });
 
@@ -75,7 +75,7 @@ export default class Samples extends React.Component<{ isAuthenticated: boolean 
             },
             {
                 key: 'featureArea', name: 'Feature Area', fieldName: 'featureArea', minWidth: 200, maxWidth: 300,
-                isResizable: true, onColumnClick: this.onColumnClick
+                isResizable: true, onColumnClick: this.onColumnClick, isMultiline: true
             }
         ];
 
@@ -134,6 +134,7 @@ export default class Samples extends React.Component<{ isAuthenticated: boolean 
                             isHeaderVisible={true}
                             onRenderItemColumn={renderItemColumn}
                             enableShimmer={isLoading}
+                            onRenderDetailsHeader={onRenderDetailsHeader}
                         />
                     </ScrollablePane>
                 </div>
@@ -172,6 +173,25 @@ export default class Samples extends React.Component<{ isAuthenticated: boolean 
     };
 }
 
+const onRenderDetailsHeader: IRenderFunction<IDetailsHeaderProps> = (props, defaultRender) => {
+    if (!props) {
+        return null;
+    }
+
+    const onRenderColumnHeaderTooltip: IRenderFunction<IDetailsColumnRenderTooltipProps> = tooltipHostProps => (
+        <TooltipHost {...tooltipHostProps} />
+    );
+
+    return (
+        <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true}>
+            {defaultRender!({
+                ...props,
+                onRenderColumnHeaderTooltip
+            })}
+        </Sticky>
+    );
+};
+
 // rendering the language and service component within the details list
 function renderItemColumn(item: ISampleItem, index: number | undefined, column: IColumn | undefined) {
     const col = column as IColumn;
@@ -202,20 +222,20 @@ function renderItemColumn(item: ISampleItem, index: number | undefined, column: 
             return <span>{language}</span>;
 
         case 'Open Pull Requests':
-            return <a href={`${url}/pulls`} target="_blank"> <span>{pullRequestCount} </span></a>
+            return <a href={`${url}/pulls`} target="_blank" rel="noopener noreferrer"> <span>{pullRequestCount} </span></a>
 
         case 'Open Issues':
-            return <a href={`${url}/issues`} target="_blank"> <span>{issueCount}</span></a>
+            return <a href={`${url}/issues`} target="_blank" rel="noopener noreferrer"> <span>{issueCount}</span></a>
 
         case 'Stars':
-            return <a href={`${url}`} target="_blank"> <FontIcon iconName="FavoriteStarFill" className={classNames.yellow} /><span>{starsCount} </span></a>;
+            return <a href={`${url}`} target="_blank" rel="noopener noreferrer"> <FontIcon iconName="FavoriteStarFill" className={classNames.yellow} /><span>{starsCount} </span></a>;
 
         case 'Feature Area':
             return <span> {featureArea} </span>;
 
         case 'Security Alerts':
             if (vulnerabilityAlertsCount > 0) {
-                return <a href={`${url}/network/alerts`} target="_blank">
+                return <a href={`${url}/network/alerts`} target="_blank" rel="noopener noreferrer">
                     <FontIcon iconName="WarningSolid" className={classNames.yellow} /> <span>{vulnerabilityAlertsCount} </span></a>;
             }
             return <span>{vulnerabilityAlertsCount} </span>;


### PR DESCRIPTION
## Description

When a user clicks on a column header, items can be sorted in ascending/descending order

Other changes include:
- Column headings are now sticky.
- The 'Home' navigation link is no longer there.
- The 'Feature Area' items are wrapped.

Screenshots:
![image](https://user-images.githubusercontent.com/18407044/76074088-d96bfa00-5fab-11ea-8c53-cf277549b56a.png)
'Open pull requests' column is sorted

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Closing issue
Fixes #65 
