### PR TITLE
Fetch repository views using the traffic api

### DIFF
--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/types/samples.ts
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/types/samples.ts
@@ -9,6 +9,7 @@ export interface IRepositoryItem {
     pullRequests: any;
     issues: any;
     stargazers: any;
+    views: number;
     forks: any;
     repositoryUrl: string;
     featureArea: string;

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/types/samples.ts
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/types/samples.ts
@@ -11,7 +11,7 @@ export interface IRepositoryItem {
     stargazers: any;
     views: number;
     forks: any;
-    repositoryUrl: string;
+    url: string;
     featureArea: string;
     vulnerabilityAlerts: any;
    

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
@@ -83,6 +83,10 @@ export default class Repositories extends React.Component<{ isAuthenticated: boo
                 isResizable: true, onColumnClick: this.onColumnClick
             },
             {
+                key: 'viewCount', name: 'Views', fieldName: 'views', minWidth: 75, maxWidth: 100,
+                isResizable: true, onColumnClick: this.onColumnClick
+            },
+            {
                 key: 'language', name: 'Language', fieldName: 'language', minWidth: 75, maxWidth: 100,
                 isResizable: true, onColumnClick: this.onColumnClick
             },
@@ -230,6 +234,7 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
     const issueCount = item.issues.totalCount;
     const starsCount = item.stargazers.totalCount;
     const forkCount = item.forks.totalCount;
+    const views = item.views;
     const repositoryUrl = item.repositoryUrl;
     const featureArea = item.featureArea;
     const vulnerabilityAlertsCount = item.vulnerabilityAlerts.totalCount;  
@@ -260,6 +265,9 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
 
         case 'Stars':
             return <a href={`${repositoryUrl}/stargazers`} target="_blank" rel="noopener noreferrer"> <FontIcon iconName="FavoriteStarFill" className={classNames.yellow} /><span>{starsCount} </span></a>;
+
+        case 'Views':
+            return <a href={`${repositoryUrl}/graphs/traffic`} target="_blank" rel="noopener noreferrer"> <span>{views} </span></a>;
 
         case 'Feature area':
             return <span> {featureArea} </span>;

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
@@ -235,7 +235,7 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
     const starsCount = item.stargazers.totalCount;
     const forkCount = item.forks.totalCount;
     const views = item.views;
-    const repositoryUrl = item.repositoryUrl;
+    const url = item.url;
     const featureArea = item.featureArea;
     const vulnerabilityAlertsCount = item.vulnerabilityAlerts.totalCount;  
 
@@ -255,26 +255,26 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
             return <span>{language}</span>;
 
         case 'Open pull requests':
-            return <a href={`${repositoryUrl}/pulls`} target="_blank" rel="noopener noreferrer"> <span>{pullRequestCount} </span></a>
+            return <a href={`${url}/pulls`} target="_blank" rel="noopener noreferrer"> <span>{pullRequestCount} </span></a>
 
         case 'Open issues':
-            return <a href={`${repositoryUrl}/issues`} target="_blank" rel="noopener noreferrer"> <span>{issueCount}</span></a>
+            return <a href={`${url}/issues`} target="_blank" rel="noopener noreferrer"> <span>{issueCount}</span></a>
 
         case 'Forks':
-            return <a href={`${repositoryUrl}/network/members`} target="_blank" rel="noopener noreferrer"> <span>{forkCount} </span></a>;
+            return <a href={`${url}/network/members`} target="_blank" rel="noopener noreferrer"> <span>{forkCount} </span></a>;
 
         case 'Stars':
-            return <a href={`${repositoryUrl}/stargazers`} target="_blank" rel="noopener noreferrer"> <FontIcon iconName="FavoriteStarFill" className={classNames.yellow} /><span>{starsCount} </span></a>;
+            return <a href={`${url}/stargazers`} target="_blank" rel="noopener noreferrer"> <FontIcon iconName="FavoriteStarFill" className={classNames.yellow} /><span>{starsCount} </span></a>;
 
         case 'Views':
-            return <a href={`${repositoryUrl}/graphs/traffic`} target="_blank" rel="noopener noreferrer"> <span>{views} </span></a>;
+            return <a href={`${url}/graphs/traffic`} target="_blank" rel="noopener noreferrer"> <span>{views} </span></a>;
 
         case 'Feature area':
             return <span> {featureArea} </span>;
 
         case 'Security Alerts':
             if (vulnerabilityAlertsCount > 0) {
-                return <a href={`${repositoryUrl}/network/alerts`} target="_blank" rel="noopener noreferrer">
+                return <a href={`${url}/network/alerts`} target="_blank" rel="noopener noreferrer">
                     <FontIcon iconName="WarningSolid" className={classNames.yellow} /> <span>{vulnerabilityAlertsCount} </span></a>;
             }
             return <span>{vulnerabilityAlertsCount} </span>;

--- a/SamplesDashboard/SamplesDashboard/Models/SampleQueries.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/SampleQueries.cs
@@ -51,6 +51,8 @@ namespace SamplesDashboard
         [JsonProperty("stargazers")]
         public Issues Stargazers { get; set; }
 
+        public int? Views { get; set; }        
+
         [JsonProperty("url")]
         public Uri Url { get; set; }
 
@@ -58,8 +60,7 @@ namespace SamplesDashboard
         public Collaborators Collaborators { get; set; }
 
         [JsonProperty("forks")]
-        public Forks Forks { get; set; }
-        
+        public Forks Forks { get; set; }        
 
         public string Language { get; internal set; }
 
@@ -69,17 +70,25 @@ namespace SamplesDashboard
 
         public PackageStatus RepositoryStatus { get; internal set; }
     }
+
     public partial class Forks
     {
         [JsonProperty("totalCount")]
         public long TotalCount { get; set; }
     }
+
     public partial class Issues
     {
         [JsonProperty("totalCount")]
         public long TotalCount { get; set; }
     }
-   
+
+    public partial class ViewData
+    {
+        [JsonProperty("count")]
+        public int Count { get; set; }       
+    }  
+    
     public partial class PageInfo
     {
         [JsonProperty("endCursor")]
@@ -88,6 +97,7 @@ namespace SamplesDashboard
         [JsonProperty("hasNextPage")]
         public bool HasNextPage { get; set; }
     }
+
     public partial class Collaborators
     {
         [JsonProperty("edges")]
@@ -114,6 +124,7 @@ namespace SamplesDashboard
         [JsonProperty("url")]
         public Uri Url { get; set; }
     }
+
     public class Organization
     {
         [JsonProperty("repository")]

--- a/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
@@ -134,7 +134,11 @@ namespace SamplesDashboard.Services
 
             return repos;            
         }
-
+        /// <summary>
+        /// Creates a github client to make calls to the API and access traffic view data
+        /// </summary>
+        /// <param name="repoName"></param>
+        /// <returns>View count</returns>
         internal async Task<int?> FetchViews(string repoName)
         {
             ViewData views;

--- a/SamplesDashboard/SamplesDashboard/Startup.cs
+++ b/SamplesDashboard/SamplesDashboard/Startup.cs
@@ -44,13 +44,13 @@ namespace SamplesDashboard
 
             services.AddHttpClient("github", c =>
             {
-                c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", Configuration.GetValue<string>("GithubAuthenticationToken"));
-
                 c.BaseAddress = new Uri("https://api.github.com/");
+                c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", Configuration.GetValue<string>("GithubAuthenticationToken"));
                 // Github API versioning
-                c.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+                c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json"));
                 // Github requires a user-agent
-                c.DefaultRequestHeaders.Add("User-Agent", "HttpClientFactory-Sample");
+                c.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(Configuration.GetValue<string>("product"), Configuration.GetValue<string>("product_version")));
+
             });
 
             services.AddSingleton<GraphQLHttpClientOptions>(provider => new GraphQLHttpClientOptions()

--- a/SamplesDashboard/SamplesDashboard/Startup.cs
+++ b/SamplesDashboard/SamplesDashboard/Startup.cs
@@ -42,6 +42,17 @@ namespace SamplesDashboard
             })
                 .AddPolicyHandler(Policies.GithubRetryPolicy);
 
+            services.AddHttpClient("github", c =>
+            {
+                c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", Configuration.GetValue<string>("GithubAuthenticationToken"));
+
+                c.BaseAddress = new Uri("https://api.github.com/");
+                // Github API versioning
+                c.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+                // Github requires a user-agent
+                c.DefaultRequestHeaders.Add("User-Agent", "HttpClientFactory-Sample");
+            });
+
             services.AddSingleton<GraphQLHttpClientOptions>(provider => new GraphQLHttpClientOptions()
             {
                 EndPoint = new Uri("https://api.github.com/graphql"),

--- a/SamplesDashboard/SamplesDashboardTests/RepositoriesServiceTests.cs
+++ b/SamplesDashboard/SamplesDashboardTests/RepositoriesServiceTests.cs
@@ -41,7 +41,7 @@ namespace SamplesDashboardTests
             Assert.NotNull(headerDetails);
             Assert.True(headerDetails["languages"] == "aspx,csharp");
             Assert.True(headerDetails["services"] == "Microsoft identity platform");
-        }
+        }       
 
         [Fact]
         public async Task ShouldGetHeaderDetailsAsync2()
@@ -57,6 +57,19 @@ namespace SamplesDashboardTests
             Assert.True(headerDetails["languages"] == "csharp,uwp");
             Assert.True(headerDetails["services"] == "Excel");
         }
+
+        [Fact]
+        public async Task ShouldGetViews()
+        {
+            // Arrange
+            var repoName = "msgraph-samples-dashboard";
+
+            // Act
+            var views = await _repositoriesService.FetchViews(repoName);
+
+            //Assert
+            Assert.NotNull(views);
+        }       
 
         [Fact]
         public async Task ShouldGetSamples()


### PR DESCRIPTION
## Description
- Fetch views from traffic data using the Github API

### Please include a summary of the change.
- Registering a http client for the Github API in our IHttpClientFactory
- Use dependency injection to request the client and create an instance of it on our service
-  Use the instance created to make calls to the API and access traffic data

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshot
![image](https://user-images.githubusercontent.com/36787645/79216332-aabc2b80-7e55-11ea-8796-a9c04f92bc56.png)

#### Closing issue
Fixes #104
