### PR TITLE
Change status column computation

### DIFF
--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Home.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Home.tsx
@@ -27,12 +27,12 @@ export default class Home extends React.Component<any> {
             >
                 <PivotItem headerText="Samples" >
                     <div>
-                        <Repositories isAuthenticated={false} title={"samples"} />
+                        <Repositories isAuthenticated={true} title={"samples"} />
                     </div>
                 </PivotItem>
                 <PivotItem headerText="SDKs">
                     <div>
-                        <Repositories isAuthenticated={false} title={"sdks"} />
+                        <Repositories isAuthenticated={true} title={"sdks"} />
                     </div>
                 </PivotItem>
             </Pivot>

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
@@ -347,23 +347,29 @@ function compare(a: any, b: any, isSortedDescending?: boolean) {
 }
 
 function checkStatus(status: number, vulnerabilityAlertsCount: number) {
-    if (status === 0 && vulnerabilityAlertsCount === 0) {
-        return <TooltipHost content="Unknown" id={'Unknown'}>
-            <span><FontIcon iconName="StatusCircleQuestionMark" className={classNames.blue} /> Unknown </span>
-        </TooltipHost>;
-    } else if (status === 1 && vulnerabilityAlertsCount === 0) {
-        return <TooltipHost content="All dependencies in this repository are up to date" id={'UptoDate'}>
-            <span><FontIcon iconName="CompletedSolid" className={classNames.green} /> Up To Date </span>
-        </TooltipHost>;
-    } else if (status > 1 && vulnerabilityAlertsCount === 0) {
-        return <TooltipHost content="At least 1 dependency in this repository has a major/minor/patch release update" id={'Update'}>
-            <span><FontIcon iconName="WarningSolid" className={classNames.yellow} /> Update </span>
-        </TooltipHost>;
-    } else if (vulnerabilityAlertsCount > 0) {
+    if (vulnerabilityAlertsCount > 0) {
         return <TooltipHost content="This repository has a security alert" id={'UrgentUpdate'}>
             <span><FontIcon iconName="StatusErrorFull" className={classNames.red} /> Urgent Update </span>
         </TooltipHost>;
     }
+    switch (status) {
+        case 0:
+            return <TooltipHost content="Unknown" id={'Unknown'}>
+                <span><FontIcon iconName="StatusCircleQuestionMark" className={classNames.blue} /> Unknown </span>
+            </TooltipHost>;
+
+        case 1:
+            return <TooltipHost content="All dependencies in this repository are up to date" id={'UptoDate'}>
+                <span><FontIcon iconName="CompletedSolid" className={classNames.green} /> Up To Date </span>
+            </TooltipHost>;
+
+        case 2:
+        case 3:
+            return <TooltipHost content="At least 1 dependency in this repository has a major/minor release update" id={'Update'}>
+                <span><FontIcon iconName="WarningSolid" className={classNames.yellow} /> Update </span>
+            </TooltipHost>;
+    }
+
 
 }
 

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
@@ -59,7 +59,7 @@ export default class Repositories extends React.Component<{ isAuthenticated: boo
                 isResizable: true, isSorted: false, isSortedDescending: false, onColumnClick: this.onColumnClick
             },
             {
-                key: 'login', name: 'Owner', fieldName: 'admins', minWidth: 150, maxWidth: 200,
+                key: 'login', name: 'Owner', fieldName: 'admins', minWidth: 100, maxWidth: 100,
                 isResizable: true, onColumnClick: this.onColumnClick, isMultiline:true
             },
             {
@@ -75,15 +75,15 @@ export default class Repositories extends React.Component<{ isAuthenticated: boo
                 isResizable: true, onColumnClick: this.onColumnClick
             },
             {
-                key: 'forkCount', name: 'Forks', fieldName: 'forks', minWidth: 75, maxWidth: 100,
+                key: 'forkCount', name: 'Forks', fieldName: 'forks', minWidth: 75, maxWidth: 75,
                 isResizable: true, onColumnClick: this.onColumnClick
             },
             {
-                key: 'starsCount', name: 'Stars', fieldName: 'stargazers', minWidth: 75, maxWidth: 100,
+                key: 'starsCount', name: 'Stars', fieldName: 'stargazers', minWidth: 75, maxWidth: 75,
                 isResizable: true, onColumnClick: this.onColumnClick
             },
             {
-                key: 'viewCount', name: 'Views', fieldName: 'views', minWidth: 75, maxWidth: 100,
+                key: 'viewCount', name: 'Views', fieldName: 'views', minWidth: 75, maxWidth: 75,
                 isResizable: true, onColumnClick: this.onColumnClick
             },
             {
@@ -91,7 +91,7 @@ export default class Repositories extends React.Component<{ isAuthenticated: boo
                 isResizable: true, onColumnClick: this.onColumnClick
             },
             {
-                key: 'featureArea', name: 'Feature area', fieldName: 'featureArea', minWidth: 200, maxWidth: 300,
+                key: 'featureArea', name: 'Feature area', fieldName: 'featureArea', minWidth: 100, maxWidth: 150,
                 isResizable: true, onColumnClick: this.onColumnClick, isMultiline: true
             }
         ];

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Repositories.tsx
@@ -249,7 +249,7 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
             return displayAdmins(ownerProfiles);            
 
         case 'Status':
-            return checkStatus(status);
+            return checkStatus(status, vulnerabilityAlertsCount);
 
         case 'Language':
             return <span>{language}</span>;
@@ -346,27 +346,23 @@ function compare(a: any, b: any, isSortedDescending?: boolean) {
     return comparison;
 }
 
-function checkStatus(status: number) {
-    switch (status) {
-        case 0:
-            return <TooltipHost content="Unknown" id={'Unknown'}>
-                <span><FontIcon iconName="StatusCircleQuestionMark" className={classNames.blue} /> Unknown </span>
-            </TooltipHost>;
-
-        case 1:
-            return <TooltipHost content="All dependencies in this repository are up to date" id={'UptoDate'}>
-                <span><FontIcon iconName="CompletedSolid" className={classNames.green} /> Up To Date </span>
-            </TooltipHost>;
-
-        case 2:
-            return <TooltipHost content="At least 1 dependency in this repository has a major/minor release update" id={'Update'}>
-                <span><FontIcon iconName="WarningSolid" className={classNames.yellow} /> Update </span>
-            </TooltipHost>;
-
-        case 3:
-            return <TooltipHost content="At least 1 dependency in this repository has a patch release update" id={'UrgentUpdate'}>
-                <span><FontIcon iconName="StatusErrorFull" className={classNames.red} /> Urgent Update </span>
-            </TooltipHost>;
+function checkStatus(status: number, vulnerabilityAlertsCount: number) {
+    if (status === 0 && vulnerabilityAlertsCount === 0) {
+        return <TooltipHost content="Unknown" id={'Unknown'}>
+            <span><FontIcon iconName="StatusCircleQuestionMark" className={classNames.blue} /> Unknown </span>
+        </TooltipHost>;
+    } else if (status === 1 && vulnerabilityAlertsCount === 0) {
+        return <TooltipHost content="All dependencies in this repository are up to date" id={'UptoDate'}>
+            <span><FontIcon iconName="CompletedSolid" className={classNames.green} /> Up To Date </span>
+        </TooltipHost>;
+    } else if (status > 1 && vulnerabilityAlertsCount === 0) {
+        return <TooltipHost content="At least 1 dependency in this repository has a major/minor/patch release update" id={'Update'}>
+            <span><FontIcon iconName="WarningSolid" className={classNames.yellow} /> Update </span>
+        </TooltipHost>;
+    } else if (vulnerabilityAlertsCount > 0) {
+        return <TooltipHost content="This repository has a security alert" id={'UrgentUpdate'}>
+            <span><FontIcon iconName="StatusErrorFull" className={classNames.red} /> Urgent Update </span>
+        </TooltipHost>;
     }
 
 }


### PR DESCRIPTION
## Description
Changed the status column to display an urgent update only when a repository has a security alert.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
![image](https://user-images.githubusercontent.com/18407044/79736985-5278a400-8303-11ea-8615-940a283e4fc4.png)

#### Closing issue
Fixes #102
