### PR TITLE
Fetch Missing Samples and Sort by Library

### DIFF
--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/utilities/copy-and-sort.ts
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/utilities/copy-and-sort.ts
@@ -1,0 +1,41 @@
+export function copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
+    const key = columnKey as keyof T;
+    const itemsSorted = items.slice(0).sort((a: T, b: T) => (compare(a[key], b[key], isSortedDescending)));
+    return itemsSorted;
+}
+
+function compare(a: any, b: any, isSortedDescending?: boolean) {
+    // Handle the possible scenario of blank inputs 
+    // and keep them at the bottom of the lists
+    if (!a) { return 1; }
+    if (!b) { return -1; }
+
+    let valueA: any;
+    let valueB: any;
+    let comparison = 0;
+
+    if (typeof a === 'string' || a instanceof String) {
+        // Use toUpperCase() to ignore character casing
+        valueA = a.toUpperCase();
+        valueB = b.toUpperCase();
+        // its an item of type number
+    } else if (typeof a === 'number' && typeof b === 'number') {
+        valueA = a;
+        valueB = b;
+    } else {
+        // its an object which has a totalCount property
+        valueA = a.totalCount;
+        valueB = b.totalCount;
+    }
+
+    if (valueA > valueB) {
+        comparison = 1;
+    } else if (valueA < valueB) {
+        comparison = -1;
+    }
+
+    if (isSortedDescending) {
+        comparison = comparison * -1;
+    }
+    return comparison;
+}

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -1,7 +1,8 @@
-import { DetailsListLayoutMode, Fabric, FontIcon, 
+import {
+    DetailsListLayoutMode, Fabric, FontIcon, FontSizes,
     IColumn, IDetailsHeaderProps, IRenderFunction, PrimaryButton,
     ScrollablePane, ScrollbarVisibility, SelectionMode, ShimmeredDetailsList, Sticky,
-    StickyPositionType, TooltipHost, FontSizes, TextField } from 'office-ui-fabric-react';
+    StickyPositionType, TooltipHost, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { Link } from 'react-router-dom';
@@ -55,7 +56,7 @@ export default class Details extends React.Component<any, any> {
             totalMajorUpdate: 0,
             totalUnknown: 0,
             totalUrgentUpdate: 0,
-            urgentUpdatePercent:0,
+            urgentUpdatePercent: 0,
             uptoDatePercent: 0,
             patchUpdatePercent: 0,
             majorUpdatePercent: 0,
@@ -248,7 +249,7 @@ export default class Details extends React.Component<any, any> {
                             </div>
                         </div>       
                         <PageTitle title={`List of ${this.allItems.length} libraries in ${repositoryDetails.name}`} />
-                        <div className={descriptionClass}> {repositoryDetails.description} </div>                         
+                        <div className={descriptionClass}> {repositoryDetails.description} </div>
                         <div className={classNames.wrapper}>
                             {this.allItems.length === 0 ?
                                 <div style={{
@@ -262,7 +263,7 @@ export default class Details extends React.Component<any, any> {
                                     <p>No data available</p>
                                 </div> :
                                 <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
-                                    <Sticky stickyPosition={StickyPositionType.Header}>                                        
+                                    <Sticky stickyPosition={StickyPositionType.Header}>
                                         <TextField
                                             className={filterListClass}
                                             label='Filter by library:'
@@ -317,7 +318,7 @@ export default class Details extends React.Component<any, any> {
             columns: newColumns,
             items: newItems
         });
-    };  
+    } 
 };
 
 // Enables the column headers to remain sticky
@@ -393,10 +394,6 @@ function checkStatus(status: number)
             </TooltipHost>;
     }
 }
-//function sortByLibrary<T>(items: T[]) {
-//    const sortedLibraries = items.sort((a, b) => (a.packageName > b.packageName) ? 1: -1);
-//    return sortedLibraries;
-//}
 
 function copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
     const key = columnKey as keyof T;

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import authService from '../../components/api-authorization/AuthorizeService';
 import PageTitle from '../../components/layout/PageTitle';
 import { IDetailsItem } from '../../types/samples';
+import { copyAndSort } from '../../utilities/copy-and-sort';
 import { filterListClass } from '../repositories/Repositories.Styles';
 import { buttonClass, classNames, descriptionClass, iconClass, linkClass } from './Details.Styles';
 import { RepositoryStatus } from './Details.types';
@@ -93,7 +94,7 @@ export default class Details extends React.Component<any, any> {
         // call the statistics function
         this.statusStatistics(this.allItems);
         this.setState({
-            items: this.sortItems(this.allItems),
+            items: copyAndSort(this.allItems, 'packageName'),
             repositoryDetails: {
             name: repositoryName,
             description: data.description,
@@ -102,11 +103,7 @@ export default class Details extends React.Component<any, any> {
             isLoading: false
         });
     }
-
-    public sortItems(items: IDetailsItem[]) {
-        const sortedItems = items.sort((a, b) => (a.packageName.toLowerCase() > b.packageName.toLowerCase()) ? 1 : -1);
-        return sortedItems;
-    }
+  
     // compute status statistics
     public statusStatistics(items: IDetailsItem[]) {
         let uptoDateCount = 0;
@@ -398,47 +395,6 @@ function checkStatus(status: number)
     }
 }
 
-function copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
-    const key = columnKey as keyof T;
-    const itemsSorted = items.slice(0).sort((a: T, b: T) => (compare(a[key], b[key], isSortedDescending)));
-    return itemsSorted;
-}
-
-function compare(a: any, b: any, isSortedDescending?: boolean) {
-    // Handle the possible scenario of blank inputs 
-    // and keep them at the bottom of the lists
-    if (!a) { return 1; }
-    if (!b) { return -1; }
-
-    let valueA: any;
-    let valueB: any;
-    let comparison = 0;
-
-    if (typeof a === 'string' || a instanceof String) {
-        // Use toUpperCase() to ignore character casing
-        valueA = a.toUpperCase();
-        valueB = b.toUpperCase();
-        // its an item of type number
-    } else if (typeof a === 'number' && typeof b === 'number') {
-        valueA = a;
-        valueB = b;
-    } else {
-        // its an object which has a totalCount property
-        valueA = a.totalCount;
-        valueB = b.totalCount;
-    }
-
-    if (valueA > valueB) {
-        comparison = 1;
-    } else if (valueA < valueB) {
-        comparison = -1;
-    }
-
-    if (isSortedDescending) {
-        comparison = comparison * -1;
-    }
-    return comparison;
-}
 
 
 

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -92,18 +92,20 @@ export default class Details extends React.Component<any, any> {
         // call the statistics function
         this.statusStatistics(this.allItems);
         this.setState({
-            items: this.allItems.sort((a, b) => (a.packageName.toLowerCase() >
-                b.packageName.toLowerCase()) ? 1 : -1),
+            items: this.sortItems(this.allItems),
             repositoryDetails: {
             name: repositoryName,
             description: data.description,
-            url: data.url
-        },
-
+                url: data.url
+            },
             isLoading: false
         });
     }
 
+    public sortItems(items: IDetailsItem[]) {
+        const sortedItems = items.sort((a, b) => (a.packageName.toLowerCase() > b.packageName.toLowerCase()) ? 1 : -1);
+        return sortedItems;
+    }
     // compute status statistics
     public statusStatistics(items: IDetailsItem[]) {
         let uptoDateCount = 0;

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -91,12 +91,13 @@ export default class Details extends React.Component<any, any> {
         // call the statistics function
         this.statusStatistics(this.allItems);
         this.setState({
-            items: this.allItems.sort((a, b) => (a.packageName.toLowerCase() > b.packageName.toLowerCase()) ? 1 : -1),
-                repositoryDetails: {
-                name: repositoryName,
-                description: data.description,
-                url: data.url
-            },
+            items: this.allItems.sort((a, b) => (a.packageName.toLowerCase() >
+                b.packageName.toLowerCase()) ? 1 : -1),
+            repositoryDetails: {
+            name: repositoryName,
+            description: data.description,
+            url: data.url
+        },
 
             isLoading: false
         });        

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -98,7 +98,7 @@ export default class Details extends React.Component<any, any> {
             repositoryDetails: {
             name: repositoryName,
             description: data.description,
-                url: data.url
+            url: data.url
             },
             isLoading: false
         });

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -1,14 +1,15 @@
 import { DetailsListLayoutMode, Fabric, FontIcon, 
     IColumn, IDetailsHeaderProps, IRenderFunction, PrimaryButton,
     ScrollablePane, ScrollbarVisibility, SelectionMode, ShimmeredDetailsList, Sticky,
-    StickyPositionType, TooltipHost } from 'office-ui-fabric-react';
+    StickyPositionType, TooltipHost, FontSizes, Stack, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { Link } from 'react-router-dom';
 import authService from '../../components/api-authorization/AuthorizeService';
 import PageTitle from '../../components/layout/PageTitle';
-import { IDetailsItem } from '../../types/samples';
+import { IDetailsItem, IRepositoryItem } from '../../types/samples';
 import { buttonClass, classNames, descriptionClass, iconClass, linkClass } from './Details.Styles';
+import { filterListClass } from '../repositories/Repositories.Styles';
 
 export default class Details extends React.Component<any, any> {
     private allItems: IDetailsItem[];
@@ -56,12 +57,12 @@ export default class Details extends React.Component<any, any> {
             uptoDatePercent: 0,
             patchUpdatePercent: 0,
             majorUpdatePercent: 0,
-            unknownPercent: 0
+            unknownPercent: 0,
         };
     }
 
     public async componentDidMount() {    
-        this.fetchData();
+        this.fetchData();        
     }
 
     // fetch repository libraries
@@ -75,7 +76,8 @@ export default class Details extends React.Component<any, any> {
                 headers: !token ? {} : { 'Authorization': `Bearer ${token}` }
             }
         );
-        const data = await response.json();
+        const data = await response.json();       
+        
         if (data.dependencyGraphManifests.nodes[0]) {
             let index;
             for (index in data.dependencyGraphManifests.nodes) {
@@ -88,14 +90,15 @@ export default class Details extends React.Component<any, any> {
         // call the statistics function
         this.statusStatistics(this.allItems);
         this.setState({
-            items: this.allItems,
-            repositoryDetails: {
+                items: this.allItems,
+                repositoryDetails: {
                 name: repositoryName,
                 description: data.description,
                 url: data.url
             },
+
             isLoading: false
-        });
+        });        
     }
 
     // compute status statistics 
@@ -105,8 +108,11 @@ export default class Details extends React.Component<any, any> {
         let majorUpdateCount = 0;
         let patchUpdateCount = 0;
         let unknownCount = 0;
+        
+        if (items.length == 0) {
+            return null;
+        }
         for (const item of items) {
-
             switch (item.status) {
                 case 1:
                     uptoDateCount = uptoDateCount + 1;
@@ -119,12 +125,13 @@ export default class Details extends React.Component<any, any> {
                     break;
                 case 4:
                     urgentUpdateCount = urgentUpdateCount + 1;
+                    break;
                 case 0:
                     unknownCount = unknownCount + 1;
                     break;
             }
         }
-        const total = this.allItems.length;
+        const total = this.allItems.length;     
         const uptoDateStats = parseFloat((uptoDateCount / total * 100).toFixed(1));
         const majorUpdateStats = parseFloat((majorUpdateCount / total * 100).toFixed(1));
         const patchUpdateStats = parseFloat((patchUpdateCount / total * 100).toFixed(1));
@@ -138,7 +145,7 @@ export default class Details extends React.Component<any, any> {
             totalUrgentUpdate: urgentUpdateCount,
             uptoDatePercent: uptoDateStats,
             majorUpdatePercent: majorUpdateStats,
-            patchUpdatePercent: patchUpdateCount,
+            patchUpdatePercent: patchUpdateStats,
             urgentUpdatePercent: urgentUpdateStats,
             unknownPercent: unknownStats
         });
@@ -146,7 +153,7 @@ export default class Details extends React.Component<any, any> {
     public render(): JSX.Element {
         const { columns, items, repositoryDetails, isLoading, totalUptoDate, totalMajorUpdate, totalPatchUpdate,
             totalUnknown, totalUrgentUpdate, uptoDatePercent, majorUpdatePercent, patchUpdatePercent,
-            urgentUpdatePercent, unknownPercent  } = this.state;
+            urgentUpdatePercent, unknownPercent } = this.state;
         return (
             <div>     
                     { isLoading ?
@@ -169,7 +176,7 @@ export default class Details extends React.Component<any, any> {
                                 Go to Repository
                         </PrimaryButton>
                         <div className='row'>
-                            <div className='col-sm'>
+                            <div className='col-sm-2'>
                                 <div className='card-details'>
                                     <div className='card-body'>
                                         <p className='card-text'>
@@ -182,7 +189,7 @@ export default class Details extends React.Component<any, any> {
                                     </div>
                                 </div>
                             </div>
-                            <div className='col-sm'>
+                            <div className='col-sm-2'>
                                 <div className='card-details'>
                                     <div className='card-body'>
                                         <p className='card-text'>
@@ -195,7 +202,7 @@ export default class Details extends React.Component<any, any> {
                                     </div>
                                 </div>
                             </div>   
-                            <div className='col-sm'>
+                            <div className='col-sm-2'>
                                 <div className='card-details'>
                                     <div className='card-body'>
                                         <p className='card-text'>
@@ -208,7 +215,7 @@ export default class Details extends React.Component<any, any> {
                                     </div>
                                 </div>
                             </div> 
-                            <div className='col-sm'>
+                            <div className='col-sm-2'>
                                 <div className='card-details'>
                                     <div className='card-body'>
 
@@ -224,7 +231,7 @@ export default class Details extends React.Component<any, any> {
                                     </div>
                                 </div>
                             </div>
-                            <div className='col-sm'>
+                            <div className='col-sm-2'>
                                 <div className='card-details'>
                                     <div className='card-body'>
                                         <p className='card-text'>
@@ -238,29 +245,57 @@ export default class Details extends React.Component<any, any> {
                                 </div>
                             </div>
                         </div>       
-                        <PageTitle title={`List of ${this.allItems.length} libraries in ${repositoryDetails.name}`}/>
-                        <div className={descriptionClass}> {repositoryDetails.description} </div>   
+                        <PageTitle title={`List of ${this.allItems.length} libraries in ${repositoryDetails.name}`} />
+                        <div className={descriptionClass}> {repositoryDetails.description} </div>                         
                         <div className={classNames.wrapper}>
-                            <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
-                                <div>
-                                    <ShimmeredDetailsList
-                                        items={items}
-                                        columns={columns}
-                                        selectionMode={SelectionMode.none}
-                                        layoutMode={DetailsListLayoutMode.justified}
-                                        isHeaderVisible={true}
-                                        onRenderItemColumn={renderItemColumn}
-                                        enableShimmer={isLoading}
-                                        onRenderDetailsHeader={onRenderDetailsHeader}
-                                    />
-                                </div>
-                            </ScrollablePane>   
+                            {this.allItems.length === 0 ?
+                                <div style={{
+                                    display: 'flex',
+                                    width: '100%',
+                                    minHeight: '200px',
+                                    justifyContent: 'center',
+                                    alignItems: 'center',
+                                    fontSize: FontSizes.large
+                                }}>
+                                    <p>No data available</p>
+                                </div> :
+                                <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
+                                    <Sticky stickyPosition={StickyPositionType.Header}>                                        
+                                        <TextField
+                                            className={filterListClass}
+                                            label='Filter by library:'
+                                            onChange={this.onFilterName}
+                                            styles={{ root: { maxWidth: '300px' } }}
+                                        />                                            
+                                    </Sticky>
+                                        <div>
+                                            <ShimmeredDetailsList
+                                                items={items}
+                                                columns={columns}
+                                                selectionMode={SelectionMode.none}
+                                                layoutMode={DetailsListLayoutMode.justified}
+                                                isHeaderVisible={true}
+                                                onRenderItemColumn={renderItemColumn}
+                                                enableShimmer={isLoading}
+                                                onRenderDetailsHeader={onRenderDetailsHeader}
+                                            />
+                                        </div>
+                                    </ScrollablePane>
+                                }                               
                         </div>
                     </Fabric>
                     }
             </div>
         );
     }
+
+    private onFilterName = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text?:
+        string | undefined): void => {
+        this.setState({
+            items: text ? this.allItems.filter(i => i.packageName.toLowerCase()
+                .indexOf(text.toLowerCase()) > -1) : this.allItems
+        });
+    };
 
     private onColumnClick = (ev: React.MouseEvent<HTMLElement>, column: IColumn): void => {
         const { columns, items } = this.state;
@@ -280,8 +315,9 @@ export default class Details extends React.Component<any, any> {
             columns: newColumns,
             items: newItems
         });
-    };
-}
+    };  
+};
+
 // Enables the column headers to remain sticky
 const onRenderDetailsHeader: IRenderFunction<IDetailsHeaderProps> = (props, defaultRender) => {
     if (!props) {
@@ -303,7 +339,7 @@ function renderItemColumn(item: IDetailsItem, index: number | undefined, column:
     const currentVersion = item.latestVersion;
     const azureSdkVersion = item.azureSdkVersion;
     const status = item.status;
-    const requirements = version.slice(2);
+    const requirements = version.slice(2);  
 
     switch (col.name) {
        
@@ -321,6 +357,9 @@ function renderItemColumn(item: IDetailsItem, index: number | undefined, column:
 
         case 'Status':
             return checkStatus(status);
+    }
+    if (item === null) {
+        return <span>No data Available</span>
     }
 }
 // checks the value of the status and displays the appropriate status
@@ -347,6 +386,7 @@ function checkStatus(status: number)
             id={'PatchUpdate'}>
                 <span><FontIcon iconName='StatusCircleInner' className={classNames.yellow} /> Patch Update </span>
             </TooltipHost>;
+
         case 4:
             return <TooltipHost content='This repository has a security alert. Please go to github to update.'
              id={'UrgentUpdate'}>

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -101,7 +101,7 @@ export default class Details extends React.Component<any, any> {
         },
 
             isLoading: false
-        });        
+        });
     }
 
     // compute status statistics
@@ -118,23 +118,23 @@ export default class Details extends React.Component<any, any> {
         for (const item of items) {
             switch (item.status) {
                 case 0:
-                    unknownCount = unknownCount + 1;
+                    unknownCount++;
                     break;
                 case 1:                    
-                    uptoDateCount = uptoDateCount + 1;
+                    uptoDateCount++;
                     break;
                 case 2:
-                    majorUpdateCount = majorUpdateCount + 1;
+                    majorUpdateCount++;
                     break;
                 case 3:
-                    patchUpdateCount = patchUpdateCount + 1;
+                    patchUpdateCount++;
                     break;
                 case 4:
-                    urgentUpdateCount = urgentUpdateCount + 1;
+                    urgentUpdateCount++;
                     break;               
             }
         }
-        const total = this.allItems.length;     
+        const total = this.allItems.length;
         const uptoDateStats = parseFloat((uptoDateCount / total * 100).toFixed(1));
         const majorUpdateStats = parseFloat((majorUpdateCount / total * 100).toFixed(1));
         const patchUpdateStats = parseFloat((patchUpdateCount / total * 100).toFixed(1));

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -91,7 +91,7 @@ export default class Details extends React.Component<any, any> {
         // call the statistics function
         this.statusStatistics(this.allItems);
         this.setState({
-                items: this.allItems,
+            items: this.allItems.sort((a, b) => (a.packageName.toLowerCase() > b.packageName.toLowerCase()) ? 1 : -1),
                 repositoryDetails: {
                 name: repositoryName,
                 description: data.description,
@@ -392,6 +392,10 @@ function checkStatus(status: number)
             </TooltipHost>;
     }
 }
+//function sortByLibrary<T>(items: T[]) {
+//    const sortedLibraries = items.sort((a, b) => (a.packageName > b.packageName) ? 1: -1);
+//    return sortedLibraries;
+//}
 
 function copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
     const key = columnKey as keyof T;

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -2,15 +2,16 @@ import {
     DetailsListLayoutMode, Fabric, FontIcon, FontSizes,
     IColumn, IDetailsHeaderProps, IRenderFunction, PrimaryButton,
     ScrollablePane, ScrollbarVisibility, SelectionMode, ShimmeredDetailsList, Sticky,
-    StickyPositionType, TextField, TooltipHost } from 'office-ui-fabric-react';
+    StickyPositionType, TextField, TooltipHost
+} from 'office-ui-fabric-react';
 import * as React from 'react';
-
 import { Link } from 'react-router-dom';
 import authService from '../../components/api-authorization/AuthorizeService';
 import PageTitle from '../../components/layout/PageTitle';
 import { IDetailsItem } from '../../types/samples';
 import { filterListClass } from '../repositories/Repositories.Styles';
 import { buttonClass, classNames, descriptionClass, iconClass, linkClass } from './Details.Styles';
+import { RepositoryStatus } from './Details.types';
 
 export default class Details extends React.Component<any, any> {
     private allItems: IDetailsItem[];
@@ -119,19 +120,19 @@ export default class Details extends React.Component<any, any> {
         }
         for (const item of items) {
             switch (item.status) {
-                case 0:
+                case RepositoryStatus.unknown:
                     unknownCount++;
                     break;
-                case 1:                    
+                case RepositoryStatus.uptoDate:                    
                     uptoDateCount++;
                     break;
-                case 2:
+                case RepositoryStatus.majorUpdate:
                     majorUpdateCount++;
                     break;
-                case 3:
+                case RepositoryStatus.patchUpdate:
                     patchUpdateCount++;
                     break;
-                case 4:
+                case RepositoryStatus.urgentUpdate:
                     urgentUpdateCount++;
                     break;               
             }

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -2,15 +2,15 @@ import {
     DetailsListLayoutMode, Fabric, FontIcon, FontSizes,
     IColumn, IDetailsHeaderProps, IRenderFunction, PrimaryButton,
     ScrollablePane, ScrollbarVisibility, SelectionMode, ShimmeredDetailsList, Sticky,
-    StickyPositionType, TooltipHost, TextField } from 'office-ui-fabric-react';
+    StickyPositionType, TextField, TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { Link } from 'react-router-dom';
 import authService from '../../components/api-authorization/AuthorizeService';
 import PageTitle from '../../components/layout/PageTitle';
 import { IDetailsItem } from '../../types/samples';
-import { buttonClass, classNames, descriptionClass, iconClass, linkClass } from './Details.Styles';
 import { filterListClass } from '../repositories/Repositories.Styles';
+import { buttonClass, classNames, descriptionClass, iconClass, linkClass } from './Details.Styles';
 
 export default class Details extends React.Component<any, any> {
     private allItems: IDetailsItem[];
@@ -319,7 +319,7 @@ export default class Details extends React.Component<any, any> {
             items: newItems
         });
     } 
-};
+}
 
 // Enables the column headers to remain sticky
 const onRenderDetailsHeader: IRenderFunction<IDetailsHeaderProps> = (props, defaultRender) => {

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -1,13 +1,13 @@
 import { DetailsListLayoutMode, Fabric, FontIcon, 
     IColumn, IDetailsHeaderProps, IRenderFunction, PrimaryButton,
     ScrollablePane, ScrollbarVisibility, SelectionMode, ShimmeredDetailsList, Sticky,
-    StickyPositionType, TooltipHost, FontSizes, Stack, TextField } from 'office-ui-fabric-react';
+    StickyPositionType, TooltipHost, FontSizes, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { Link } from 'react-router-dom';
 import authService from '../../components/api-authorization/AuthorizeService';
 import PageTitle from '../../components/layout/PageTitle';
-import { IDetailsItem, IRepositoryItem } from '../../types/samples';
+import { IDetailsItem } from '../../types/samples';
 import { buttonClass, classNames, descriptionClass, iconClass, linkClass } from './Details.Styles';
 import { filterListClass } from '../repositories/Repositories.Styles';
 
@@ -54,15 +54,17 @@ export default class Details extends React.Component<any, any> {
             totalPatchUpdate: 0,
             totalMajorUpdate: 0,
             totalUnknown: 0,
+            totalUrgentUpdate: 0,
+            urgentUpdatePercent:0,
             uptoDatePercent: 0,
             patchUpdatePercent: 0,
             majorUpdatePercent: 0,
-            unknownPercent: 0,
+            unknownPercent: 0
         };
     }
 
     public async componentDidMount() {    
-        this.fetchData();        
+        this.fetchData(); 
     }
 
     // fetch repository libraries
@@ -76,8 +78,7 @@ export default class Details extends React.Component<any, any> {
                 headers: !token ? {} : { 'Authorization': `Bearer ${token}` }
             }
         );
-        const data = await response.json();       
-        
+        const data = await response.json();
         if (data.dependencyGraphManifests.nodes[0]) {
             let index;
             for (index in data.dependencyGraphManifests.nodes) {
@@ -101,7 +102,7 @@ export default class Details extends React.Component<any, any> {
         });        
     }
 
-    // compute status statistics 
+    // compute status statistics
     public statusStatistics(items: IDetailsItem[]) {
         let uptoDateCount = 0;
         let urgentUpdateCount = 0;
@@ -109,12 +110,15 @@ export default class Details extends React.Component<any, any> {
         let patchUpdateCount = 0;
         let unknownCount = 0;
         
-        if (items.length == 0) {
+        if (items.length === 0) {
             return null;
         }
         for (const item of items) {
             switch (item.status) {
-                case 1:
+                case 0:
+                    unknownCount = unknownCount + 1;
+                    break;
+                case 1:                    
                     uptoDateCount = uptoDateCount + 1;
                     break;
                 case 2:
@@ -125,10 +129,7 @@ export default class Details extends React.Component<any, any> {
                     break;
                 case 4:
                     urgentUpdateCount = urgentUpdateCount + 1;
-                    break;
-                case 0:
-                    unknownCount = unknownCount + 1;
-                    break;
+                    break;               
             }
         }
         const total = this.allItems.length;     
@@ -136,7 +137,7 @@ export default class Details extends React.Component<any, any> {
         const majorUpdateStats = parseFloat((majorUpdateCount / total * 100).toFixed(1));
         const patchUpdateStats = parseFloat((patchUpdateCount / total * 100).toFixed(1));
         const urgentUpdateStats = parseFloat((urgentUpdateCount / total * 100).toFixed(1));
-        const unknownStats = parseFloat((unknownCount / total * 100).toFixed(1));
+        const unknownStats = parseFloat((unknownCount / total * 100).toFixed(1));       
         this.setState({
             totalUptoDate: uptoDateCount,
             totalMajorUpdate: majorUpdateCount,
@@ -339,7 +340,7 @@ function renderItemColumn(item: IDetailsItem, index: number | undefined, column:
     const currentVersion = item.latestVersion;
     const azureSdkVersion = item.azureSdkVersion;
     const status = item.status;
-    const requirements = version.slice(2);  
+    const requirements = version.slice(2);
 
     switch (col.name) {
        
@@ -357,10 +358,7 @@ function renderItemColumn(item: IDetailsItem, index: number | undefined, column:
 
         case 'Status':
             return checkStatus(status);
-    }
-    if (item === null) {
-        return <span>No data Available</span>
-    }
+    }   
 }
 // checks the value of the status and displays the appropriate status
 function checkStatus(status: number)

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.types.ts
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.types.ts
@@ -1,0 +1,3 @@
+export enum RepositoryStatus{
+    unknown, uptoDate, majorUpdate, patchUpdate, urgentUpdate
+}

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
@@ -142,7 +142,7 @@ IRepositoryState> {
         let majorUpdateCount = 0;
         let urgentUpdateCount = 0;
         for (const item of items) {
-            if (item.vulnerabilityAlerts != null) {
+            if (item.vulnerabilityAlerts !== null) {
                 if (item.vulnerabilityAlerts.totalCount > 0) {
                     urgentUpdateCount = urgentUpdateCount + 1;
                 } else {
@@ -367,9 +367,9 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
     const views = item.views;
     const url = item.url;
     const featureArea = item.featureArea;
-    if (item.vulnerabilityAlerts == null) {
+    if (item.vulnerabilityAlerts === null) {
         return null;
-    };
+    }
     const vulnerabilityAlertsCount = item.vulnerabilityAlerts.totalCount;
 
     switch (col.name) {

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
@@ -142,7 +142,7 @@ IRepositoryState> {
         let majorUpdateCount = 0;
         let urgentUpdateCount = 0;
         for (const item of items) {
-            if (item.vulnerabilityAlerts?.totalCount > 0) {
+            if (item.vulnerabilityAlerts && item.vulnerabilityAlerts && item.vulnerabilityAlerts.totalCount > 0) {
                 urgentUpdateCount++;
             }
             else {

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
@@ -142,23 +142,22 @@ IRepositoryState> {
         let majorUpdateCount = 0;
         let urgentUpdateCount = 0;
         for (const item of items) {
-            if (item.vulnerabilityAlerts !== null) {
-                if (item.vulnerabilityAlerts.totalCount > 0) {
-                    urgentUpdateCount = urgentUpdateCount + 1;
-                } else {
-                    switch (item.repositoryStatus) {
-                        case 1:
-                            uptoDateCount = uptoDateCount + 1;
-                            break;
-                        case 2:
-                            majorUpdateCount = majorUpdateCount + 1;
-                            break;
-                        case 3:
-                            patchUpdateCount = patchUpdateCount + 1;
-                            break;
-                    }
+            if (item.vulnerabilityAlerts?.totalCount > 0) {
+                urgentUpdateCount++;
+            }
+            else {
+                switch (item.repositoryStatus) {
+                    case 1:
+                        uptoDateCount++;
+                        break;
+                    case 2:
+                        majorUpdateCount++;
+                        break;
+                    case 3:
+                        patchUpdateCount++;
+                        break;
                 }
-            }           
+            }
         }
         const total = this.allItems.length;
         const uptoDateStats = parseFloat((uptoDateCount / total * 100).toFixed(1));
@@ -410,7 +409,7 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
         case 'Feature area':
             return <span> {featureArea} </span>;
 
-        case 'Security Alerts':           
+        case 'Security Alerts':
             if (vulnerabilityAlertsCount > 0) {
                 return <a href={`${url}/network/alerts`} target='_blank' rel='noopener noreferrer'>
                     <FontIcon iconName='WarningSolid' className={classNames.yellow} /> 
@@ -421,7 +420,7 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
 }
 
 function copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
-    const key = columnKey as keyof T;    
+    const key = columnKey as keyof T;
     const itemsSorted = items.slice(0).sort((a: T, b: T) => (compare(a[key], b[key], isSortedDescending)));
     return itemsSorted;
 }

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
@@ -12,6 +12,8 @@ import { Link } from 'react-router-dom';
 
 import authService from '../../components/api-authorization/AuthorizeService';
 import { IRepositoryItem, IRepositoryState } from '../../types/samples';
+import { copyAndSort } from '../../utilities/copy-and-sort';
+import { RepositoryStatus } from '../details/Details.types';
 import { classNames, filterListClass } from '../repositories/Repositories.Styles';
 
 initializeIcons();
@@ -147,13 +149,13 @@ IRepositoryState> {
             }
             else {
                 switch (item.repositoryStatus) {
-                    case 1:
+                    case RepositoryStatus.uptoDate:
                         uptoDateCount++;
                         break;
-                    case 2:
+                    case RepositoryStatus.majorUpdate:
                         majorUpdateCount++;
                         break;
-                    case 3:
+                    case RepositoryStatus.patchUpdate:
                         patchUpdateCount++;
                         break;
                 }
@@ -366,7 +368,7 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
     const views = item.views;
     const url = item.url;
     const featureArea = item.featureArea;
-    if (item.vulnerabilityAlerts === null) {
+    if (!item.vulnerabilityAlerts) {
         return null;
     }
     const vulnerabilityAlertsCount = item.vulnerabilityAlerts.totalCount;
@@ -418,13 +420,6 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
             return <span>{vulnerabilityAlertsCount} </span>;
     }
 }
-
-function copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
-    const key = columnKey as keyof T;
-    const itemsSorted = items.slice(0).sort((a: T, b: T) => (compare(a[key], b[key], isSortedDescending)));
-    return itemsSorted;
-}
-
 function displayAdmins(ownerProfiles: any)
 {
     if (ownerProfiles !== null) {
@@ -449,43 +444,6 @@ function displayAdmins(ownerProfiles: any)
         return <span>{}</span>;
     }
 }
-
-function compare(a: any, b: any, isSortedDescending?: boolean) {
-    // Handle the possible scenario of blank inputs 
-    // and keep them at the bottom of the lists
-    if (!a) { return 1; }
-    if (!b) { return -1; }
-
-    let valueA: any;
-    let valueB: any;
-    let comparison = 0;
-
-    if (typeof a === 'string' || a instanceof String) {
-        // Use toUpperCase() to ignore character casing
-        valueA = a.toUpperCase();
-        valueB = b.toUpperCase();
-        // its an item of type number
-    } else if (typeof a === 'number' && typeof b === 'number') {
-        valueA = a;
-        valueB = b;
-    }else {
-        // its an object which has a totalCount property
-        valueA = a.totalCount;
-        valueB = b.totalCount;
-    }
-
-    if (valueA > valueB) {
-        comparison = 1;
-    } else if (valueA < valueB) {
-        comparison = -1;
-    }
-
-    if (isSortedDescending) {
-        comparison = comparison * -1;
-    }
-    return comparison;
-}
-
 function checkStatus(status: number) {    
     switch (status) {
         case 0:

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
@@ -11,7 +11,6 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import authService from '../../components/api-authorization/AuthorizeService';
-import PageTitle from '../../components/layout/PageTitle';
 import { IRepositoryItem, IRepositoryState } from '../../types/samples';
 import { classNames, filterListClass } from '../repositories/Repositories.Styles';
 
@@ -371,7 +370,7 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
     if (item.vulnerabilityAlerts == null) {
         return null;
     };
-    const vulnerabilityAlertsCount = item.vulnerabilityAlerts.totalCount;  
+    const vulnerabilityAlertsCount = item.vulnerabilityAlerts.totalCount;
 
     switch (col.name) {
         case 'Name':

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
@@ -417,11 +417,11 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
                     <span>{vulnerabilityAlertsCount} </span></a>;
             }
             return <span>{vulnerabilityAlertsCount} </span>;
-
     }
 }
+
 function copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
-    const key = columnKey as keyof T;
+    const key = columnKey as keyof T;    
     const itemsSorted = items.slice(0).sort((a: T, b: T) => (compare(a[key], b[key], isSortedDescending)));
     return itemsSorted;
 }

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.tsx
@@ -143,21 +143,23 @@ IRepositoryState> {
         let majorUpdateCount = 0;
         let urgentUpdateCount = 0;
         for (const item of items) {
-            if (item.vulnerabilityAlerts.totalCount > 0) {
-                urgentUpdateCount = urgentUpdateCount + 1;
-            } else {
-                switch (item.repositoryStatus) {
-                    case 1:
-                        uptoDateCount = uptoDateCount + 1;
-                        break;
-                    case 2:
-                        majorUpdateCount = majorUpdateCount + 1;
-                        break;
-                    case 3:
-                        patchUpdateCount = patchUpdateCount + 1;
-                        break;
+            if (item.vulnerabilityAlerts != null) {
+                if (item.vulnerabilityAlerts.totalCount > 0) {
+                    urgentUpdateCount = urgentUpdateCount + 1;
+                } else {
+                    switch (item.repositoryStatus) {
+                        case 1:
+                            uptoDateCount = uptoDateCount + 1;
+                            break;
+                        case 2:
+                            majorUpdateCount = majorUpdateCount + 1;
+                            break;
+                        case 3:
+                            patchUpdateCount = patchUpdateCount + 1;
+                            break;
+                    }
                 }
-            }            
+            }           
         }
         const total = this.allItems.length;
         const uptoDateStats = parseFloat((uptoDateCount / total * 100).toFixed(1));
@@ -366,6 +368,9 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
     const views = item.views;
     const url = item.url;
     const featureArea = item.featureArea;
+    if (item.vulnerabilityAlerts == null) {
+        return null;
+    };
     const vulnerabilityAlertsCount = item.vulnerabilityAlerts.totalCount;  
 
     switch (col.name) {
@@ -406,7 +411,7 @@ function renderItemColumn(item: IRepositoryItem, index: number | undefined, colu
         case 'Feature area':
             return <span> {featureArea} </span>;
 
-        case 'Security Alerts':
+        case 'Security Alerts':           
             if (vulnerabilityAlertsCount > 0) {
                 return <a href={`${url}/network/alerts`} target='_blank' rel='noopener noreferrer'>
                     <FontIcon iconName='WarningSolid' className={classNames.yellow} /> 

--- a/SamplesDashboard/SamplesDashboard/Services/AzureSdkService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/AzureSdkService.cs
@@ -82,19 +82,18 @@ namespace SamplesDashboard.Services
             string azureSdkVersion = String.Empty;
 
             var sdks = await FetchAzureSdkVersions();
-            if (sdks != null)
+            if (sdks == null)
             {
-                foreach (var sdk in sdks)
+                return  String.Empty;  
+            }
+            foreach (var sdk in sdks)
+            {
+                if (sdk.Key == packageName)
                 {
-                    if (sdk.Key == packageName)
-                    {
-                        azureSdkVersion = sdk.Value;
-                    }
+                    azureSdkVersion = sdk.Value;
                 }
             }
-            
             return azureSdkVersion;
         }
-
     }
 }

--- a/SamplesDashboard/SamplesDashboard/Services/AzureSdkService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/AzureSdkService.cs
@@ -82,13 +82,17 @@ namespace SamplesDashboard.Services
             string azureSdkVersion = String.Empty;
 
             var sdks = await FetchAzureSdkVersions();
-            foreach (var sdk in sdks)
+            if (sdks != null)
             {
-                if (sdk.Key == packageName)
+                foreach (var sdk in sdks)
                 {
-                    azureSdkVersion = sdk.Value;
+                    if (sdk.Key == packageName)
+                    {
+                        azureSdkVersion = sdk.Value;
+                    }
                 }
             }
+            
             return azureSdkVersion;
         }
 

--- a/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
@@ -71,7 +71,7 @@ namespace SamplesDashboard.Services
             {
                 Query = @"
 	            {              
-                  search(query: ""org:microsoftgraph" + $"{name}" + @" in:name archived:false"", type: REPOSITORY, first: 100 " + $"{cursorString}" + @" ) {
+                  search(query: ""org:microsoftgraph" + $"{name}" + @" in:name archived:false fork:true"", type: REPOSITORY, first: 100 " + $"{cursorString}" + @" ) {
                         nodes {
                                 ... on Repository {
                                     name 
@@ -311,10 +311,10 @@ namespace SamplesDashboard.Services
                     }
                     latestVersion = nonPreviewVersions.LastOrDefault();
                 }
-            }
-                  
+            }                  
             return latestVersion;
         }
+
         /// <summary>
         /// Gets the repository's details and updates the status field in the dependencies
         /// </summary>
@@ -359,10 +359,9 @@ namespace SamplesDashboard.Services
                             latestVersion = dependency.repository?.releases?.nodes?.FirstOrDefault()?.tagName;
                             break;
                     }
-
                     dependency.latestVersion = latestVersion;
                     dependency.azureSdkVersion = azureSdkVersion;
-
+                  
                     //calculate status normally for repos without security alerts
                     if (vulnerabilityCount == 0)
                     {

--- a/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
@@ -13,9 +13,8 @@ using Semver;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using SamplesDashboard.Models;
-using System.IO;
-using Newtonsoft.Json;
 using Octokit;
+using System.Text.RegularExpressions;
 
 namespace SamplesDashboard.Services
 {
@@ -146,8 +145,8 @@ namespace SamplesDashboard.Services
             //remove localized repos to reduce repetition of samples
             foreach (var repo in repositories.ToList())
             {
-                //var localizedrepos;
-                if (repo.Name.Contains("."))
+                Regex regex = new Regex (@".[a-z]{2}-[A-Z]{2}");
+                if(regex.IsMatch(repo?.Name))
                 {
                     repositories.Remove(repo);
                 }
@@ -165,7 +164,7 @@ namespace SamplesDashboard.Services
             var views = await githubclient.Repository.Traffic.GetViews(owner, repoName, new RepositoryTrafficRequest(TrafficDayOrWeek.Week));
             return views?.Count;
         }
-
+        
         /// <summary>
         /// Uses githubclient to fetch a list of contributors
         /// </summary>

--- a/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
@@ -143,7 +143,7 @@ namespace SamplesDashboard.Services
                 repositories.AddRange(nextRepos);
             }
 
-            //remove localized repos
+            //remove localized repos to reduce repetition of samples
             foreach (var repo in repositories.ToList())
             {
                 //var localizedrepos;
@@ -337,7 +337,7 @@ namespace SamplesDashboard.Services
 
                 // Go through each dependency in the dependency manifest
                 foreach (var dependency in dependencies)
-                {                    
+                {
                     var currentVersion = dependency.requirements;
                     if (string.IsNullOrEmpty(currentVersion)) continue;
                     
@@ -361,7 +361,7 @@ namespace SamplesDashboard.Services
                     }
                     dependency.latestVersion = latestVersion;
                     dependency.azureSdkVersion = azureSdkVersion;
-                  
+                    
                     //calculate status normally for repos without security alerts
                     if (vulnerabilityCount == 0)
                     {

--- a/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
@@ -293,23 +293,26 @@ namespace SamplesDashboard.Services
         {
             var nugetPackageVersions = await _nugetService.GetPackageVersions(packageName);
             var latestVersion = nugetPackageVersions.LastOrDefault()?.ToString();
-
-            //check if current version is preview, return latest version, whether preview or non-preview
-            if (currentVersion.Contains("preview") && latestVersion.Contains("preview"))
+            if(latestVersion != null)
             {
-                return latestVersion;
-            }
-            //check if only latest version is preview, set to latest non-preview version
-            else if (latestVersion.Contains("preview"))
-            {
-                var nonPreviewVersions = new List<string>();
-                foreach (var version in nugetPackageVersions)
+                //check if current version is preview, return latest version, whether preview or non-preview
+                if (currentVersion.Contains("preview") && latestVersion.Contains("preview"))
                 {
-                    if (!version.ToString().Contains("preview"))
-                        nonPreviewVersions.Add(version.ToString());
+                    return latestVersion;
                 }
-                latestVersion = nonPreviewVersions.LastOrDefault();
-            }           
+                //check if only latest version is preview, set to latest non-preview version
+                else if (latestVersion.Contains("preview"))
+                {
+                    var nonPreviewVersions = new List<string>();
+                    foreach (var version in nugetPackageVersions)
+                    {
+                        if (!version.ToString().Contains("preview"))
+                            nonPreviewVersions.Add(version.ToString());
+                    }
+                    latestVersion = nonPreviewVersions.LastOrDefault();
+                }
+            }
+                  
             return latestVersion;
         }
         /// <summary>


### PR DESCRIPTION
## Description

- Adds all the missing samples and filters out the localized ones to be displayed on the dashboard.
- Also adds a filtering tool for one to search by library name
- Sorts the libraries in the details page alphabetically
### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Filter and Sort

![image](https://user-images.githubusercontent.com/36787645/93098791-edf22300-f6af-11ea-928f-89a1e17bf9a7.png)

### Missing Java sdks
![image](https://user-images.githubusercontent.com/36787645/93150848-e90a8f00-f702-11ea-93e1-b0d55d2304cf.png)



#### Closing issue
Fixes #131, #141 
