### PR TITLE
FHL Hack on dashboard

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (web)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/SamplesDashboard/SamplesDashboard/bin/Debug/net5.0/SamplesDashboard.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/SamplesDashboard/SamplesDashboard",
+      "stopAtEntry": false,
+      // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\\\bNow listening on:\\\\s+(https?://\\\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      }
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "cSpell.ignoreWords": [
+    "adal",
+    "angularjs",
+    "aspnetmvcapp",
+    "dependabot",
+    "devx",
+    "edcgnui",
+    "intune",
+    "localdb",
+    "msgraph",
+    "msgraphcore",
+    "mssqllocaldb",
+    "oidc",
+    "signin",
+    "xunit"
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/SamplesDashboard/SamplesDashboard/SamplesDashboard.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/SamplesDashboard/SamplesDashboard/SamplesDashboard.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "${workspaceFolder}/SamplesDashboard/SamplesDashboard/SamplesDashboard.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -10,8 +10,24 @@ You'll need to do this to run Samples Dashboard locally.
 
 3. Install [Visual Studio 2019](https://visualstudio.microsoft.com/vs).
 
-4. Generate a [github token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) and set it as an authentication token in appsettings.json. 
+4. Generate a [github token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) and set it as an authentication token in appsettings.json.
 
-5. Open a terminal, go to the ClientApp folder, and run `npm install` to install the web client dependencies. 
+5. Open a terminal, go to the ClientApp folder, and run `npm install` to install the web client dependencies.
 
 6. Run the app.
+
+## YAML Schema
+
+If you do not have the YAML header in README, you can add metadata in devx.yml in the root of the repo. Here's the 3 relevant bits of information.
+
+```yml
+---
+languages:
+- python
+- html
+extensions:
+    services:
+    - Security
+dependencyFile: demo/GraphTutorial/app/build.gradle
+---
+```

--- a/SamplesDashboard/SamplesDashboard/ClientApp/package-lock.json
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "samplesdashboard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/custom.css
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/custom.css
@@ -3,21 +3,9 @@
     max-width: 100%;
     background: #f7f7f7;
     position:relative;
-    
+
 }
 .card {
-    background: #fff;
-    height: 8rem;
-    width: 20vw;
-    position: relative;
-    display: flex;
-    flex-wrap: wrap;
-    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
-    transition: 0.3s;
-    margin: 5px;
-    margin-bottom:0px;
-}
-.card-details {
     background: #fff;
     height: 8rem;
     width: 15vw;
@@ -27,13 +15,15 @@
     box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
     transition: 0.3s;
     margin: 5px;
-    margin-bottom: 0px;
-
+    margin-bottom:0px;
 }
 .card-text {
     font-size: 14px;
     padding-bottom: 0px;
     text-align: center;
+}
+.card-text .ms-Icon {
+    vertical-align: text-top;
 }
 .card-footer {
     background: #fff;

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/types/samples.ts
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/types/samples.ts
@@ -14,7 +14,9 @@ export interface IRepositoryItem {
     url: string;
     featureArea: string;
     vulnerabilityAlerts: any;
-   
+    lastUpdated: any;
+    identityStatus: any;
+    graphStatus: any;
 }
 
 export interface IDetailsItem {
@@ -36,10 +38,12 @@ export interface IRepositoryState {
     isLoading: boolean;
     totalUptoDate: number;
     totalPatchUpdate: number;
+    totalMinorUpdate: number;
     totalMajorUpdate: number;
     totalUrgentUpdate: number;
     uptoDatePercent: number;
     patchUpdatePercent: number;
+    minorUpdatePercent: number;
     majorUpdatePercent: number;
     urgentUpdatePercent: number;
 }

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Home.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/Home.tsx
@@ -30,7 +30,7 @@ export default class Home extends React.Component<any> {
                         <Repositories isAuthenticated={true} title={'samples'} />
                     </div>
                 </PivotItem>
-                <PivotItem headerText='Code Projects'>
+                <PivotItem headerText='SDKs'>
                     <div>
                         <Repositories isAuthenticated={true} title={'sdks'} />
                     </div>

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.Styles.js
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.Styles.js
@@ -1,5 +1,5 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+exports.__esModule = true;
 var Styling_1 = require("office-ui-fabric-react/lib/Styling");
 exports.iconClass = Styling_1.mergeStyles({
     fontSize: 15,
@@ -34,9 +34,10 @@ exports.classNames = Styling_1.mergeStyleSets({
         margin: '5px'
     },
     detailList: { padding: '10px' },
-    yellow: [{ color: '#ffaa44' }, exports.iconClass],
     green: [{ color: '#498205' }, exports.iconClass],
+    yellowGreen: [{ color: '#8cbd18' }, exports.iconClass],
+    yellow: [{ color: '#ffaa44' }, exports.iconClass],
+    orange: [{ color: '#fd7e14' }, exports.iconClass],
     red: [{ color: '#d13438' }, exports.iconClass],
     blue: [{ color: '#0078d4' }, exports.iconClass]
 });
-//# sourceMappingURL=Details.Styles.js.map

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.Styles.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.Styles.tsx
@@ -13,8 +13,8 @@ export const buttonClass = mergeStyles({
 
 export const descriptionClass = mergeStyles({
     paddingLeft: '10px',
-    paddingBottom: '10px' 
- 
+    paddingBottom: '10px'
+
 });
 
 export const linkClass = mergeStyles({
@@ -35,11 +35,13 @@ export const classNames = mergeStyleSets({
         flexWrap: 'wrap',
         boxShadow: '0 4px 8px 0 rgba(0,0,0,0.2)',
         transition: '0.3s',
-        margin: '5px'    
+        margin: '5px'
     },
     detailList: { padding: '10px' },
-    yellow: [{ color: '#ffaa44' }, iconClass],
     green: [{ color: '#498205' }, iconClass],
+    yellowGreen: [{ color: '#8cbd18' }, iconClass],
+    yellow: [{ color: '#ffaa44' }, iconClass],
+    orange: [{ color: '#fd7e14' }, iconClass],
     red: [{ color: '#d13438' }, iconClass],
     blue: [{ color: '#0078d4' }, iconClass]
 });

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.tsx
@@ -24,21 +24,21 @@ export default class Details extends React.Component<any, any> {
         const { match: { params } } = this.props;
         const repositoryName = params.name;
         const columns: IColumn[] = [
-            { key: 'packageName', name: 'Library', fieldName: 'packageName', minWidth: 300, maxWidth: 400, 
-            isRowHeader: true, isResizable: true, isSorted: false, isSortedDescending: false, 
+            { key: 'packageName', name: 'Library', fieldName: 'packageName', minWidth: 300, maxWidth: 400,
+            isRowHeader: true, isResizable: true, isSorted: false, isSortedDescending: false,
             onColumnClick: this.onColumnClick
             },
-            { key: 'requirements', name: 'Used version', fieldName: 'requirements', minWidth: 200, maxWidth: 300, 
+            { key: 'requirements', name: 'Used version', fieldName: 'requirements', minWidth: 200, maxWidth: 300,
                 isResizable: true
             },
-            { key: 'currentVersion', name: 'Latest version', fieldName: 'tagName', minWidth: 200, 
+            { key: 'currentVersion', name: 'Latest version', fieldName: 'tagName', minWidth: 200,
                 maxWidth: 300, isResizable: true
             },
-            { key: 'status', name: 'Status', fieldName: 'status', minWidth: 200, maxWidth: 300, 
+            { key: 'status', name: 'Status', fieldName: 'status', minWidth: 200, maxWidth: 300,
                 isResizable: true, onColumnClick: this.onColumnClick
             }
         ];
-        // Adding Azure SDK column to SDK repository details 
+        // Adding Azure SDK column to SDK repository details
         if ((repositoryName.includes('sdk')) || (repositoryName.includes('SDK'))) {
             const azureSdkColumn: IColumn = {
                 key: 'azureSdkVersion', name: 'Azure SDK version', fieldName: 'azureSdkVersion',
@@ -66,8 +66,8 @@ export default class Details extends React.Component<any, any> {
         };
     }
 
-    public async componentDidMount() {    
-        this.fetchData(); 
+    public async componentDidMount() {
+        this.fetchData();
     }
 
     // fetch repository libraries
@@ -87,8 +87,8 @@ export default class Details extends React.Component<any, any> {
             for (index in data.dependencyGraphManifests.nodes) {
                 if (data.dependencyGraphManifests.nodes.hasOwnProperty(index)) {
                     data.dependencyGraphManifests.nodes[index].dependencies.nodes.forEach((element: any) =>
-                        this.allItems.push(element)); 
-                }               
+                        this.allItems.push(element));
+                }
             }
         }
         // call the statistics function
@@ -103,7 +103,7 @@ export default class Details extends React.Component<any, any> {
             isLoading: false
         });
     }
-  
+
     // compute status statistics
     public statusStatistics(items: IDetailsItem[]) {
         let uptoDateCount = 0;
@@ -111,7 +111,7 @@ export default class Details extends React.Component<any, any> {
         let majorUpdateCount = 0;
         let patchUpdateCount = 0;
         let unknownCount = 0;
-        
+
         if (items.length === 0) {
             return null;
         }
@@ -120,7 +120,7 @@ export default class Details extends React.Component<any, any> {
                 case RepositoryStatus.unknown:
                     unknownCount++;
                     break;
-                case RepositoryStatus.uptoDate:                    
+                case RepositoryStatus.uptoDate:
                     uptoDateCount++;
                     break;
                 case RepositoryStatus.majorUpdate:
@@ -131,7 +131,7 @@ export default class Details extends React.Component<any, any> {
                     break;
                 case RepositoryStatus.urgentUpdate:
                     urgentUpdateCount++;
-                    break;               
+                    break;
             }
         }
         const total = this.allItems.length;
@@ -139,7 +139,7 @@ export default class Details extends React.Component<any, any> {
         const majorUpdateStats = parseFloat((majorUpdateCount / total * 100).toFixed(1));
         const patchUpdateStats = parseFloat((patchUpdateCount / total * 100).toFixed(1));
         const urgentUpdateStats = parseFloat((urgentUpdateCount / total * 100).toFixed(1));
-        const unknownStats = parseFloat((unknownCount / total * 100).toFixed(1));       
+        const unknownStats = parseFloat((unknownCount / total * 100).toFixed(1));
         this.setState({
             totalUptoDate: uptoDateCount,
             totalMajorUpdate: majorUpdateCount,
@@ -158,7 +158,7 @@ export default class Details extends React.Component<any, any> {
             totalUnknown, totalUrgentUpdate, uptoDatePercent, majorUpdatePercent, patchUpdatePercent,
             urgentUpdatePercent, unknownPercent } = this.state;
         return (
-            <div>     
+            <div>
                     { isLoading ?
                     <div /> :
                     <Fabric>
@@ -180,7 +180,7 @@ export default class Details extends React.Component<any, any> {
                         </PrimaryButton>
                         <div className='row'>
                             <div className='col-sm-2'>
-                                <div className='card-details'>
+                                <div className='card'>
                                     <div className='card-body'>
                                         <p className='card-text'>
                                             <FontIcon iconName='StatusCircleInner' className={classNames.red} />
@@ -193,7 +193,7 @@ export default class Details extends React.Component<any, any> {
                                 </div>
                             </div>
                             <div className='col-sm-2'>
-                                <div className='card-details'>
+                                <div className='card'>
                                     <div className='card-body'>
                                         <p className='card-text'>
                                             <FontIcon iconName='StatusCircleInner' className={classNames.green} />
@@ -204,9 +204,9 @@ export default class Details extends React.Component<any, any> {
                                         </div>
                                     </div>
                                 </div>
-                            </div>   
+                            </div>
                             <div className='col-sm-2'>
-                                <div className='card-details'>
+                                <div className='card'>
                                     <div className='card-body'>
                                         <p className='card-text'>
                                             <FontIcon iconName='StatusCircleInner' className={classNames.yellow} />
@@ -217,9 +217,9 @@ export default class Details extends React.Component<any, any> {
                                         </div>
                                     </div>
                                 </div>
-                            </div> 
+                            </div>
                             <div className='col-sm-2'>
-                                <div className='card-details'>
+                                <div className='card'>
                                     <div className='card-body'>
 
                                         <p className='card-text'>
@@ -235,7 +235,7 @@ export default class Details extends React.Component<any, any> {
                                 </div>
                             </div>
                             <div className='col-sm-2'>
-                                <div className='card-details'>
+                                <div className='card'>
                                     <div className='card-body'>
                                         <p className='card-text'>
                                             <FontIcon iconName='StatusCircleInner' className={classNames.blue} />
@@ -247,7 +247,7 @@ export default class Details extends React.Component<any, any> {
                                     </div>
                                 </div>
                             </div>
-                        </div>       
+                        </div>
                         <PageTitle title={`List of ${this.allItems.length} libraries in ${repositoryDetails.name}`} />
                         <div className={descriptionClass}> {repositoryDetails.description} </div>
                         <div className={classNames.wrapper}>
@@ -269,7 +269,7 @@ export default class Details extends React.Component<any, any> {
                                             label='Filter by library:'
                                             onChange={this.onFilterName}
                                             styles={{ root: { maxWidth: '300px' } }}
-                                        />                                            
+                                        />
                                     </Sticky>
                                         <div>
                                             <ShimmeredDetailsList
@@ -284,7 +284,7 @@ export default class Details extends React.Component<any, any> {
                                             />
                                         </div>
                                     </ScrollablePane>
-                                }                               
+                                }
                         </div>
                     </Fabric>
                     }
@@ -318,7 +318,7 @@ export default class Details extends React.Component<any, any> {
             columns: newColumns,
             items: newItems
         });
-    } 
+    }
 }
 
 // Enables the column headers to remain sticky
@@ -345,7 +345,7 @@ function renderItemColumn(item: IDetailsItem, index: number | undefined, column:
     const requirements = version.slice(2);
 
     switch (col.name) {
-       
+
         case 'Library':
             return <span>{packageName} </span>;
 
@@ -360,7 +360,7 @@ function renderItemColumn(item: IDetailsItem, index: number | undefined, column:
 
         case 'Status':
             return checkStatus(status);
-    }   
+    }
 }
 // checks the value of the status and displays the appropriate status
 function checkStatus(status: number)
@@ -377,18 +377,22 @@ function checkStatus(status: number)
             </TooltipHost>;
 
         case 2:
-            return <TooltipHost content='This library has a patch or major/minor release update' id={'Update'}>
-                <span><FontIcon iconName='StatusCircleInner' className={classNames.yellow} /> Update </span>
+            return <TooltipHost content='This library has a patch update' id={'PatchUpdate'}>
+                <span><FontIcon iconName='StatusCircleInner' className={classNames.yellowGreen} /> Patch Update </span>
             </TooltipHost>;
 
         case 3:
-            return <TooltipHost content='Atleast 1 dependency in this repository has a patch update.' 
-            id={'PatchUpdate'}>
-                <span><FontIcon iconName='StatusCircleInner' className={classNames.yellow} /> Patch Update </span>
+            return <TooltipHost content='This library has a minor release update' id={'MinorUpdate'}>
+                <span><FontIcon iconName='StatusCircleInner' className={classNames.yellow} /> Minor Update </span>
             </TooltipHost>;
 
         case 4:
-            return <TooltipHost content='This repository has a security alert. Please go to github to update.'
+            return <TooltipHost content='This library has a major release update.' id={'Update'}>
+                <span><FontIcon iconName='StatusCircleInner' className={classNames.orange} /> Major Update </span>
+            </TooltipHost>;
+
+        case 5:
+            return <TooltipHost content='This library has a security alert. Please go to GitHub to update.'
              id={'UrgentUpdate'}>
                 <span><FontIcon iconName='StatusCircleInner' className={classNames.red} /> Urgent Update </span>
             </TooltipHost>;

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.types.ts
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/details/Details.types.ts
@@ -1,3 +1,3 @@
 export enum RepositoryStatus{
-    unknown, uptoDate, majorUpdate, patchUpdate, urgentUpdate
+    unknown, uptoDate, patchUpdate, minorUpdate, majorUpdate, urgentUpdate
 }

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.Styles.js
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.Styles.js
@@ -1,5 +1,5 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+exports.__esModule = true;
 var Styling_1 = require("office-ui-fabric-react/lib/Styling");
 exports.filterListClass = Styling_1.mergeStyles({
     display: 'block',
@@ -9,7 +9,8 @@ exports.iconClass = Styling_1.mergeStyles({
     fontSize: 15,
     height: 15,
     width: 15,
-    margin: '0 5px'
+    margin: '0 5px',
+    verticalAlign: 'sub'
 });
 exports.classNames = Styling_1.mergeStyleSets({
     wrapper: {
@@ -23,8 +24,10 @@ exports.classNames = Styling_1.mergeStyleSets({
         margin: '5px'
     },
     detailList: { padding: '10px' },
-    yellow: [{ color: '#ffaa44' }, exports.iconClass],
     green: [{ color: '#498205' }, exports.iconClass],
+    yellowGreen: [{ color: '#8cbd18' }, exports.iconClass],
+    yellow: [{ color: '#ffaa44' }, exports.iconClass],
+    orange: [{ color: '#fd7e14' }, exports.iconClass],
     red: [{ color: '#d13438' }, exports.iconClass],
     blue: [{ color: '#0078d4' }, exports.iconClass],
     statsCard: {
@@ -38,8 +41,9 @@ exports.classNames = Styling_1.mergeStyleSets({
         margin: '5px'
     },
     yellowText: { color: '#ffaa44' },
+    yellowGreenText: { color: '#8cbd18' },
     greenText: { color: '#498205' },
+    orangeText: { color: '#fd7e14' },
     redText: { color: '#d13438' },
     blueText: { color: '#0078d4' }
 });
-//# sourceMappingURL=Repositories.Styles.js.map

--- a/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.Styles.tsx
+++ b/SamplesDashboard/SamplesDashboard/ClientApp/src/views/repositories/Repositories.Styles.tsx
@@ -9,7 +9,8 @@ export const iconClass = mergeStyles({
     fontSize: 15,
     height: 15,
     width: 15,
-    margin: '0 5px'
+    margin: '0 5px',
+    verticalAlign: 'sub'
 });
 
 export const classNames = mergeStyleSets({
@@ -24,8 +25,10 @@ export const classNames = mergeStyleSets({
         margin: '5px'
     },
     detailList: { padding: '10px' },
-    yellow: [{ color: '#ffaa44' }, iconClass],
     green: [{ color: '#498205' }, iconClass],
+    yellowGreen: [{ color: '#8cbd18' }, iconClass],
+    yellow: [{ color: '#ffaa44' }, iconClass],
+    orange: [{ color: '#fd7e14' }, iconClass],
     red: [{ color: '#d13438' }, iconClass],
     blue: [{ color: '#0078d4' }, iconClass],
     statsCard: {
@@ -38,8 +41,10 @@ export const classNames = mergeStyleSets({
         transition: '0.3s',
         margin: '5px'
     },
-    yellowText: {color: '#ffaa44' },
+    yellowText: { color: '#ffaa44' },
+    yellowGreenText: { color: '#8cbd18' },
     greenText: { color: '#498205' },
+    orangeText: { color: '#fd7e14' },
     redText: { color: '#d13438' },
     blueText: { color: '#0078d4' }
 });

--- a/SamplesDashboard/SamplesDashboard/Constants.cs
+++ b/SamplesDashboard/SamplesDashboard/Constants.cs
@@ -11,11 +11,62 @@ namespace SamplesDashboard
     {
         private static readonly IEnumerable<string> SdkList = new[]
         {
-            "sdk", "microsoft-graph-explorer", "devx-api", "raptor", "msgraph-cli", "samples-dashboard"
+            "sdk", "microsoft-graph-explorer", "devx-api", "raptor", "\\\"msgraph-cli\\\"", "samples-dashboard"
         };
         private static readonly IEnumerable<string> SamplesList = new[] {"sample", "training"};
         public static readonly string Sdks = SdkList.BuildQueryString();
         public static readonly string Samples = SamplesList.BuildQueryString();
         public const string Timeout = "timeout";
+
+        // Names of known identity libraries from Microsoft
+        // as they appear in dependency graph or file.
+        // MUST be converted to lowercase
+        public static readonly string[] IdentityLibraries =
+        {
+            // .NET
+            "microsoft.identity.client",
+            "microsoft.identity.web",
+            "microsoft.identitymodel.clients.activedirectory",
+            "microsoft.authentication.webassembly.msal",
+            // JavaScript
+            "@azure/msal-node",
+            "@azure/msal-browser",
+            "@azure/msal-react",
+            "@azure/msal-angular",
+            "@azure/msal-angularjs",
+            "msal", // Also Python, Obj-C
+            "adal-angular",
+            "passport-azure-ad",
+            // Java
+            "com.microsoft.identity.client:msal",
+            "com.microsoft.azure:msal4j",
+            "com.azure:azure-identity",
+            "com.microsoft.aad:adal",
+            // Ruby
+            "adal"
+        };
+
+        // Names of known Graph SDKs from Microsoft
+        // as they appear in dependency graph or file.
+        // MUST be converted to lowercase
+        public static readonly string[] GraphSdks = {
+            // .NET
+            "microsoft.graph",
+            "microsoft.graph.beta",
+            // JavaScript
+            "@microsoft/microsoft-graph-client",
+            // Java
+            "com.microsoft.graph:microsoft-graph",
+            "com.microsoft.graph:microsoft-graph-core",
+            "com.microsoft.graph:microsoft-graph-beta",
+            // PHP
+            "microsoft/microsoft-graph",
+            // Python
+            "msgraphcore",
+            // Ruby
+            "microsoft_graph",
+            // Obj-C
+            "msgraphclientsdk"
+        };
     }
 }

--- a/SamplesDashboard/SamplesDashboard/Controllers/RepositoriesController.cs
+++ b/SamplesDashboard/SamplesDashboard/Controllers/RepositoriesController.cs
@@ -34,15 +34,15 @@ namespace SamplesDashboard.Controllers
         [Produces("application/json")]
         [Route("api/samples")]
         [HttpGet]
-        public async Task<IActionResult> GetSamplesListAsync()        
+        public async Task<IActionResult> GetSamplesListAsync()
         {
 
             if (!_cache.TryGetValue(Constants.Samples, out var samples))
-            {   
+            {
 
                 samples = await _repositoriesService.GetRepositories(Constants.Samples);
 
-                //Read timeout from config file 
+                //Read timeout from config file
                 var cacheEntryOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(_config.GetValue<double>(Constants.Timeout)));
 
                 // Save data in cache.
@@ -57,13 +57,13 @@ namespace SamplesDashboard.Controllers
         [Route("api/sdks")]
         [HttpGet]
         public async Task<IActionResult> GetSdksListAsync()
-        {     
+        {
 
             if (!_cache.TryGetValue(Constants.Sdks, out var sdkList))
             {
                 sdkList = await _repositoriesService.GetRepositories(Constants.Sdks);
 
-                //Read timeout from config file 
+                //Read timeout from config file
                 var cacheEntryOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(_config.GetValue<double>(Constants.Timeout)));
 
                 // Save data in cache.
@@ -79,7 +79,7 @@ namespace SamplesDashboard.Controllers
         public async Task<IActionResult> GetRepositoriesAsync(string id)
         {
             if (!_cache.TryGetValue(id, out Repository repository))
-            {                
+            {
                 repository = await _repositoriesService.GetRepository(id);
                 var cacheEntryOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(_config.GetValue<double>(Constants.Timeout)));
                 _cache.Set(id, repository, cacheEntryOptions);
@@ -95,9 +95,9 @@ namespace SamplesDashboard.Controllers
         public Dto()
         {
             this.Dependencies = new List<DependenciesNode>();
-            Features = new List<string>();           
+            Features = new List<string>();
         }
-      
+
         public Node Sample { get; set; }
         public List<DependenciesNode> Dependencies { get; set; }
         public List<string> Features { get; set; }

--- a/SamplesDashboard/SamplesDashboard/Models/MavenQuery.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/MavenQuery.cs
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SamplesDashboard.Models
+{
+    public class MavenQuery
+    {
+        public MavenResponse Response { get; set; }
+
+    }
+    public partial class MavenResponse
+    {
+        public int NumFound { get; set; }
+        public List<MavenPackageInfo> Docs { get; set; }
+    }
+
+    public partial class MavenPackageInfo
+    {
+        public string Id { get; set; }
+        public string LatestVersion { get; set; }
+    }
+}

--- a/SamplesDashboard/SamplesDashboard/Models/MavenQuery.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/MavenQuery.cs
@@ -3,7 +3,6 @@
 // ------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace SamplesDashboard.Models
 {

--- a/SamplesDashboard/SamplesDashboard/Models/MicrosoftMaintainerStatus.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/MicrosoftMaintainerStatus.cs
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace SamplesDashboard.Models
+{
+    public class MicrosoftMaintainerStatus
+    {
+        [JsonProperty("repo")]
+        public string Repository { get; set; }
+        [JsonProperty("org")]
+        public string Organization { get; set; }
+        public MicrosoftMaintainers Maintainers { get; set; }
+    }
+}

--- a/SamplesDashboard/SamplesDashboard/Models/MicrosoftMaintainers.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/MicrosoftMaintainers.cs
@@ -1,16 +1,14 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace SamplesDashboard.Models
 {
-    public enum PackageStatus
+    public class MicrosoftMaintainers
     {
-        Unknown = 0,
-        UpToDate = 1,
-        PatchUpdate = 2,
-        MinorVersionUpdate = 3,
-        MajorVersionUpdate = 4,
-        UrgentUpdate = 5
+        public List<MicrosoftUser> Individuals { get; set; }
+        public string SecurityGroupMail { get; set; }
     }
 }

--- a/SamplesDashboard/SamplesDashboard/Models/MicrosoftUser.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/MicrosoftUser.cs
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace SamplesDashboard.Models
+{
+    public class MicrosoftUser
+    {
+        public string DisplayName { get; set; }
+        public string GivenName { get; set; }
+        public string Id { get; set; }
+        public string Mail { get; set; }
+        public string MailNickname { get; set; }
+        public string UserPrincipalName { get; set; }
+        public string UserType { get; set; }
+    }
+}

--- a/SamplesDashboard/SamplesDashboard/Models/SampleQueries.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/SampleQueries.cs
@@ -51,7 +51,7 @@ namespace SamplesDashboard
         [JsonProperty("stargazers")]
         public Issues Stargazers { get; set; }
 
-        public int? Views { get; set; }        
+        public int? Views { get; set; }
 
         [JsonProperty("url")]
         public Uri Url { get; set; }
@@ -60,15 +60,25 @@ namespace SamplesDashboard
         public Contributors Contributors { get; set; }
 
         [JsonProperty("forks")]
-        public Forks Forks { get; set; }        
+        public Forks Forks { get; set; }
+
+        [JsonProperty("defaultBranchRef")]
+        public Branch DefaultBranch { get; set; }
+
+        [JsonProperty("pushedAt")]
+        public DateTimeOffset LastUpdated { get; set; }
 
         public string Language { get; internal set; }
 
         public string FeatureArea { get; internal set; }
 
-        public bool HasDependendencies { get; set; }
+        public bool HasDependencies { get; set; }
 
         public PackageStatus RepositoryStatus { get; internal set; }
+
+        public PackageStatus IdentityStatus { get; set; }
+
+        public PackageStatus GraphStatus { get; set; }
     }
     public partial class VulnerabilityAlerts
     {
@@ -117,9 +127,9 @@ namespace SamplesDashboard
     public partial class ViewData
     {
         [JsonProperty("count")]
-        public int Count { get; set; }       
-    }  
-    
+        public int Count { get; set; }
+    }
+
     public partial class PageInfo
     {
         [JsonProperty("endCursor")]
@@ -127,12 +137,12 @@ namespace SamplesDashboard
 
         [JsonProperty("hasNextPage")]
         public bool HasNextPage { get; set; }
-    }    
+    }
 
     public partial class Contributors
     {
         [JsonProperty("login")]
-        public string Login { get; set; }       
+        public string Login { get; set; }
 
         [JsonProperty("url")]
         public Uri HtmlUrl { get; set; }
@@ -146,6 +156,9 @@ namespace SamplesDashboard
 
     public class Repository
     {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
         [JsonProperty("description")]
         public string Description { get; set; }
 
@@ -158,7 +171,14 @@ namespace SamplesDashboard
         [JsonProperty("dependencyGraphManifests")]
         public DependencyGraphManifests DependencyGraphManifests { get; set; }
 
+        [JsonProperty("defaultBranchRef")]
+        public Branch DefaultBranch { get; set; }
+
         public PackageStatus highestStatus { get; set; }
+
+        public PackageStatus IdentityStatus { get; set; }
+
+        public PackageStatus GraphStatus { get; set; }
     }
 
     public class DependencyGraphManifests
@@ -204,7 +224,7 @@ namespace SamplesDashboard
 
         public Releases releases { get; set; }
 
-    }   
+    }
 
     public class Releases
     {
@@ -215,5 +235,15 @@ namespace SamplesDashboard
     {
         public string name { get; set; }
         public string tagName { get; set; }
+    }
+
+    public class Branch
+    {
+        public string Name { get; set; }
+    }
+
+    public enum SupportedDependencyFileType
+    {
+        Unsupported, Gradle, PodFile
     }
 }

--- a/SamplesDashboard/SamplesDashboard/Models/YamlHeader.cs
+++ b/SamplesDashboard/SamplesDashboard/Models/YamlHeader.cs
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace SamplesDashboard.Models
+{
+    public class YamlHeaderExtensions
+    {
+        public string[] Services { get; set; }
+    }
+    public class YamlHeader
+    {
+        public string[] Languages { get; set; }
+        public YamlHeaderExtensions Extensions { get; set; }
+        public string DependencyFile { get; set; }
+    }
+}

--- a/SamplesDashboard/SamplesDashboard/SamplesDashboard.csproj
+++ b/SamplesDashboard/SamplesDashboard/SamplesDashboard.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.28.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
@@ -41,6 +42,7 @@
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="YamlDotNet" Version="9.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SamplesDashboard/SamplesDashboard/Services/MavenService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/MavenService.cs
@@ -1,0 +1,73 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using SamplesDashboard.Models;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SamplesDashboard.Services
+{
+    /// <summary>
+    /// This class contains search.maven.org queries to be used by the samples
+    /// </summary>
+    public class MavenService
+    {
+        private readonly IHttpClientFactory _clientFactory;
+        private readonly IConfiguration _config;
+        private IMemoryCache _cache;
+
+        public MavenService(IHttpClientFactory clientFactory, IConfiguration config, IMemoryCache memoryCache)
+        {
+            _clientFactory = clientFactory;
+            _config = config;
+            _cache = memoryCache;
+        }
+
+        /// <summary>
+        ///Creates a httpclient to query Maven's registry to get package details
+        /// </summary>
+        /// <param name="packageName"></param>
+        /// <returns>latest package version</returns>
+        public async Task<string> GetLatestVersion(string packageName)
+        {
+            MavenQuery mavenData;
+            if (!_cache.TryGetValue($"maven: {packageName}", out mavenData))
+            {
+                var httpClient = _clientFactory.CreateClient();
+
+                var packageParts = packageName.Split(':');
+                var apiUrl = $"https://search.maven.org/solrsearch/select?q=g:%22{packageParts[0]}%22%20AND%20a:%22{packageParts[1]}%22&rows=1&wt=json";
+                HttpResponseMessage responseMessage = await httpClient.GetAsync(apiUrl);
+
+                if (responseMessage.IsSuccessStatusCode)
+                {
+
+                    using (var stream = await responseMessage.Content.ReadAsStreamAsync())
+                    using (var streamReader = new StreamReader(stream))
+                    using (var jsonTextReader = new JsonTextReader(streamReader))
+
+                    {
+                        var serializer = new JsonSerializer();
+                        mavenData = serializer.Deserialize<MavenQuery>(jsonTextReader);
+
+                        var cacheEntryOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(_config.GetValue<double>(Constants.Timeout)));
+                        _cache.Set($"maven: {packageName}", mavenData, cacheEntryOptions);
+                    }
+                }
+            }
+
+            if (mavenData?.Response?.NumFound > 0)
+            {
+                return mavenData?.Response?.Docs[0]?.LatestVersion;
+            }
+
+            return "";
+        }
+    }
+}

--- a/SamplesDashboard/SamplesDashboard/Services/MicrosoftOpenSourceService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/MicrosoftOpenSourceService.cs
@@ -22,6 +22,9 @@ namespace SamplesDashboard.Services
         private readonly IConfiguration _config;
         private readonly ILogger<MicrosoftOpenSourceService> _logger;
         private readonly IConfidentialClientApplication _cca;
+
+        // This single scope is the permission scope needed to call the
+        // Microsoft Open Source GitHub portal API. Don't change this.
         private static readonly string[] _scopes =
             { "api://5bc5e692-fe67-4053-8d49-9e2863718bfb/.default" };
 
@@ -52,8 +55,13 @@ namespace SamplesDashboard.Services
             try
             {
                 var tokenResponse = await _cca
-                .AcquireTokenForClient(_scopes)
-                .ExecuteAsync();
+                    .AcquireTokenForClient(_scopes)
+                    .ExecuteAsync();
+
+                if (tokenResponse == null)
+                {
+                    throw new MsalException(MsalError.AuthenticationFailed, "AcquireTokenForClient returned null");
+                }
 
                 var client = _clientFactory.CreateClient();
 

--- a/SamplesDashboard/SamplesDashboard/Services/MicrosoftOpenSourceService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/MicrosoftOpenSourceService.cs
@@ -1,0 +1,86 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
+using Newtonsoft.Json;
+using SamplesDashboard.Models;
+
+namespace SamplesDashboard.Services
+{
+    /// <summary>
+    /// This class contains query services for the Microsoft Open Source GitHub portal
+    /// </summary>
+    public class MicrosoftOpenSourceService
+    {
+        private readonly IHttpClientFactory _clientFactory;
+        private readonly IConfiguration _config;
+        private readonly ILogger<MicrosoftOpenSourceService> _logger;
+        private readonly IConfidentialClientApplication _cca;
+        private static readonly string[] _scopes =
+            { "api://5bc5e692-fe67-4053-8d49-9e2863718bfb/.default" };
+
+        public MicrosoftOpenSourceService(
+          IHttpClientFactory clientFactory,
+          IConfiguration configuration,
+          ILogger<MicrosoftOpenSourceService> logger)
+        {
+            _clientFactory = clientFactory;
+            _config = configuration;
+            _logger = logger;
+
+            _cca = ConfidentialClientApplicationBuilder
+                .Create(_config["AuthenticationConfig:Microsoft:ClientId"])
+                .WithClientSecret(_config["AuthenticationConfig:Microsoft:ClientSecret"])
+                .WithTenantId(_config["AuthenticationConfig:Microsoft:TenantId"])
+                .Build();
+        }
+
+        /// <summary>
+        /// Gets the maintainer status for a given repository
+        /// <summary>
+        /// <param name="organization"></param>
+        /// <param name="repoName"></param>
+        /// <returns> The individuals and/or security group configured as maintainers in the portal
+        public async Task<MicrosoftMaintainerStatus> GetMicrosoftMaintainers(string organization, string repoName)
+        {
+            try
+            {
+                var tokenResponse = await _cca
+                .AcquireTokenForClient(_scopes)
+                .ExecuteAsync();
+
+                var client = _clientFactory.CreateClient();
+
+                var apiPath =
+                    $"https://repos.opensource.microsoft.com/api/maintainers/org/{organization}/repo/{repoName}?api-version=2017-09-01";
+                var request = new HttpRequestMessage(HttpMethod.Get, apiPath);
+                request.Headers.Authorization =
+                    new AuthenticationHeaderValue("Bearer", tokenResponse.AccessToken);
+
+                var apiResponse = await client.SendAsync(request);
+
+                if (apiResponse.IsSuccessStatusCode)
+                {
+                    var result = JsonConvert
+                        .DeserializeObject<MicrosoftMaintainerStatus>(
+                            await apiResponse.Content.ReadAsStringAsync());
+
+                    return result;
+                }
+            }
+            catch (MsalException ex)
+            {
+                _logger.LogError(ex,
+                    $"Error getting Microsoft maintainers for {repoName}");
+            }
+
+            return null;
+        }
+    }
+}

--- a/SamplesDashboard/SamplesDashboard/Startup.cs
+++ b/SamplesDashboard/SamplesDashboard/Startup.cs
@@ -75,8 +75,8 @@ namespace SamplesDashboard
                 c.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(Configuration.GetValue<string>("product"), Configuration.GetValue<string>("product_version")));
             })
                 .AddPolicyHandler(Policies.GithubRetryPolicy)
-                .AddHttpMessageHandler<GithubAuthHandler>();          
-          
+                .AddHttpMessageHandler<GithubAuthHandler>();
+
             services.AddSingleton<GraphQLHttpClientOptions>(provider => new GraphQLHttpClientOptions()
             {
                 EndPoint = new Uri("https://api.github.com/graphql"),
@@ -85,8 +85,10 @@ namespace SamplesDashboard
             services.AddSingleton<RepositoriesService>();
             services.AddSingleton<NugetService>();
             services.AddSingleton<NpmService>();
+            services.AddSingleton<MavenService>();
             services.AddSingleton<AzureSdkService>();
             services.AddSingleton<GithubAuthService>();
+            services.AddSingleton<MicrosoftOpenSourceService>();
             services.AddHostedService<RepositoryHostedService>();
             services.AddScoped<GithubAuthHandler>();
 
@@ -124,7 +126,7 @@ namespace SamplesDashboard
             app.UseAuthentication();
             app.UseIdentityServer();
             app.UseAuthorization();
-            app.UseCors(); 
+            app.UseCors();
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(

--- a/SamplesDashboard/SamplesDashboardTests/MavenServiceTests.cs
+++ b/SamplesDashboard/SamplesDashboardTests/MavenServiceTests.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+using SamplesDashboard.Services;
+using System.Threading.Tasks;
+using SamplesDashboardTests.Factories;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SamplesDashboardTests
+{
+    public class MavenServiceTests : IClassFixture<BaseWebApplicationFactory<TestStartup>>
+    {
+        private readonly MavenService _mavenService;
+        private readonly ITestOutputHelper _helper;
+
+        public MavenServiceTests(BaseWebApplicationFactory<TestStartup> applicationFactory, ITestOutputHelper helper)
+        {
+            _helper = helper;
+            _mavenService = applicationFactory.Services.GetService<MavenService>();
+        }
+
+        [Fact]
+        public async Task ShouldGetMavenVersions()
+        {
+            // Arrange
+            var packageName = "com.microsoft.graph:microsoft-graph";
+
+            // Act
+            var latestVersion = await _mavenService.GetLatestVersion(packageName);
+
+            //Assert
+            Assert.False(string.IsNullOrEmpty(latestVersion));
+        }
+    }
+}

--- a/SamplesDashboard/SamplesDashboardTests/MicrosoftOpenSourceServiceTests.cs
+++ b/SamplesDashboard/SamplesDashboardTests/MicrosoftOpenSourceServiceTests.cs
@@ -1,0 +1,42 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+using SamplesDashboard.Services;
+using System.Threading.Tasks;
+using SamplesDashboardTests.Factories;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SamplesDashboardTests
+{
+    public class MicrosoftOpenSourceServiceTests : IClassFixture<BaseWebApplicationFactory<TestStartup>>
+    {
+        private readonly ITestOutputHelper _helper;
+        private readonly MicrosoftOpenSourceService _microsoftService;
+
+        public MicrosoftOpenSourceServiceTests(BaseWebApplicationFactory<TestStartup> applicationFactory, ITestOutputHelper helper)
+        {
+            _helper = helper;
+            _microsoftService = applicationFactory.Services.GetService<MicrosoftOpenSourceService>();
+        }
+
+        [Fact]
+        public async Task ShouldGetMicrosoftMaintainers()
+        {
+            // Arrange
+            var organization = "microsoftgraph";
+            var repoName = "msgraph-training-aspnet-core";
+
+            // Act
+            var maintainers = await _microsoftService.GetMicrosoftMaintainers(organization, repoName);
+
+            // Assert
+            Assert.Single(maintainers.Maintainers.Individuals);
+            Assert.Equal("Jason Johnston (HE/HIM)", maintainers.Maintainers.Individuals[0].DisplayName);
+            Assert.NotNull(maintainers.Maintainers.SecurityGroupMail);
+            Assert.Equal("graphsampleadmins@microsoft.com", maintainers.Maintainers.SecurityGroupMail);
+        }
+    }
+}

--- a/SamplesDashboard/SamplesDashboardTests/RepositoriesServiceTests.cs
+++ b/SamplesDashboard/SamplesDashboardTests/RepositoriesServiceTests.cs
@@ -32,9 +32,10 @@ namespace SamplesDashboardTests
         {
             //Arrange
             var sampleName = "aspnetcore-connect-sample";
+            var branchName = "main";
 
             //Act
-            var headerDetails = await _repositoriesService.GetHeaderDetails(sampleName);
+            var headerDetails = await _repositoriesService.GetHeaderDetails(sampleName, branchName);
             _helper.WriteLine(headerDetails["languages"]);
 
             //Assert
@@ -48,12 +49,13 @@ namespace SamplesDashboardTests
         {
             //Arrange
             var sampleName = "meetings-capture-sample";
+            var branchName = "master";
 
             //Act
-            var headerDetails = await _repositoriesService.GetHeaderDetails(sampleName);            
+            var headerDetails = await _repositoriesService.GetHeaderDetails(sampleName, branchName);
 
             //Assert
-            Assert.Empty(headerDetails);        
+            Assert.Empty(headerDetails);
         }
 
         [Fact]
@@ -61,9 +63,10 @@ namespace SamplesDashboardTests
         {
             //Arrange
             var sampleName = "nodejs-webhooks-rest-sample";
+            var branchName = "main";
 
             //Act
-            var headerDetails = await _repositoriesService.GetHeaderDetails(sampleName);
+            var headerDetails = await _repositoriesService.GetHeaderDetails(sampleName, branchName);
             _helper.WriteLine(headerDetails["languages"]);
 
             //Assert
@@ -77,15 +80,16 @@ namespace SamplesDashboardTests
         {
             //Arrange
             var sampleName = "python-security-rest-sample";
+            var branchName = "master";
 
             //Act
-            var headerDetails = await _repositoriesService.GetHeaderDetails(sampleName);
+            var headerDetails = await _repositoriesService.GetHeaderDetails(sampleName, branchName);
 
             //Assert
             Assert.NotNull(headerDetails);
             Assert.True(headerDetails["languages"] == "python,html");
             Assert.True(headerDetails["services"] == "Security");
-        }    
+        }
 
         [Fact]
         public async Task ShouldGetSamples()
@@ -145,7 +149,7 @@ namespace SamplesDashboardTests
             }
         }
 
-        [Fact]  
+        [Fact]
         public async Task ShouldGetDependencies()
         {
             //Arrange
@@ -178,21 +182,21 @@ namespace SamplesDashboardTests
             //Assert
             Assert.NotNull(repository);
             Assert.Empty(nodes);
-        }       
+        }
 
         [Theory]
         [InlineData("1.2.3", "1.2.3", PackageStatus.UpToDate)]
         [InlineData("1.2.3.4", "1.2.3.4", PackageStatus.UpToDate)]
-        [InlineData("1.2.1", "1.3.1", PackageStatus.Update)]
-        [InlineData("2.2.1", "3.0.0", PackageStatus.Update)]
+        [InlineData("1.2.1", "1.3.1", PackageStatus.MinorVersionUpdate)]
+        [InlineData("2.2.1", "3.0.0", PackageStatus.MajorVersionUpdate)]
         [InlineData("1.2.0", "1.2.1", PackageStatus.PatchUpdate)]
         [InlineData("1.2.0", "v1.2.1", PackageStatus.PatchUpdate)]
         [InlineData("v1.2.0", "v1.2.1", PackageStatus.PatchUpdate)]
-        [InlineData("1.2.0", "2.1.0-Preview.1", PackageStatus.Update)]
-        [InlineData("1.2.0", "2.1.0-alpha.1", PackageStatus.Update)]
+        [InlineData("1.2.0", "2.1.0-Preview.1", PackageStatus.MajorVersionUpdate)]
+        [InlineData("1.2.0", "2.1.0-alpha.1", PackageStatus.MajorVersionUpdate)]
         [InlineData("2.1.0", "2.1.0-Preview.1", PackageStatus.PatchUpdate)]
         [InlineData("2.1.0", "2.1.0-2", PackageStatus.PatchUpdate)]
-        [InlineData("2.1.0", "3.1.0-2", PackageStatus.Update)]
+        [InlineData("2.1.0", "3.1.0-2", PackageStatus.MajorVersionUpdate)]
         [InlineData("2.1.0", "1.8<2.1", PackageStatus.Unknown)]
         [InlineData("2.1.0", "Unknown", PackageStatus.Unknown)]
         [InlineData("2.1.0", "", PackageStatus.Unknown)]
@@ -213,12 +217,26 @@ namespace SamplesDashboardTests
             //Arrange
             var sample = "msgraph-training-phpapp";
 
-            //Act 
+            //Act
             var dependency = await _repositoriesService.GetRepository(sample);
             var latestVersion = _repositoriesService.UpdateRepositoryStatus(dependency).ToString();
 
             Assert.NotNull(latestVersion);
-        }       
+        }
+
+        [Fact]
+        public async Task ShouldGetDependenciesFromGradleFile()
+        {
+            // Arrange
+            var repoName = "msgraph-training-android";
+            var defaultBranch = "main";
+            var dependencyFile = "/demo/GraphTutorial/app/build.gradle";
+
+            // Act
+            var dependencies = await _repositoriesService.BuildDependencyGraphFromFile(repoName, defaultBranch, dependencyFile);
+
+            Assert.NotNull(dependencies);
+            Assert.NotEmpty(dependencies);
+        }
     }
 }
- 


### PR DESCRIPTION
Made numerous changes and improvements.

- Owners field is now pulled from GitHub Management Portal for Open Source instead of guessed at from GitHub collaborators. (Note this requires onboarding of production app ID before it will work)
- Implemented basic dependency graph support for Gradle-based Java projects. GitHub does not support Gradle when it builds it's graph.
- Implemented Maven service to look up latest versions of Java dependencies (to support the Gradle graph support).
- Separated minor and major updates into their own statuses, added additional card to repo list to show their percentages
- Identity library and Graph SDK updates statuses are called out in the repo list
- Adjusted repo filters to remove private repos from the list
- Refactored to remove tutorial localization repos from the list *before* querying GitHub for their stats.
- Added a "Last updated" column in the repo list
- List is sorted alphabetically by default
- Added an alternative to the YAML header in the README. Repos can opt to add a dev.yml file in the root and add the relevant info there.
- Adjusted how percentages on repo list page are calculated. Repos with a status of "unknown" are removed from the total before calculating percentage.

## Description

Please include a summary of the change.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Testing
Please describe the tests that you ran to verify your changes.

#### Closing issue
Fixes #145 
