### PR TITLE
Added User-Agent to HttpClient

### DIFF
--- a/SamplesDashboard/SamplesDashboard/SamplesDashboard.csproj
+++ b/SamplesDashboard/SamplesDashboard/SamplesDashboard.csproj
@@ -14,17 +14,17 @@
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.2.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.2.0" />
-    <PackageReference Include="GraphQL.Client" Version="4.0.1" />
-    <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="4.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
-    <PackageReference Include="Microsoft.IdentityModel.KeyVaultExtensions" Version="6.14.1" />
+    <PackageReference Include="GraphQL.Client" Version="4.0.2" />
+    <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="4.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.13" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.1" />
+    <PackageReference Include="Microsoft.IdentityModel.KeyVaultExtensions" Version="6.15.0" />
     <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Semver" Version="2.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.0" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 

--- a/SamplesDashboard/SamplesDashboard/Services/CocoaPodsService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/CocoaPodsService.cs
@@ -35,7 +35,7 @@ namespace SamplesDashboard.Services
             var cacheKey = $"cocoapods:{packageName}";
             if (!_cacheService.TryGetValue(cacheKey, out string packageVersion))
             {
-                var httpClient = _clientFactory.CreateClient();
+                var httpClient = _clientFactory.CreateClient("Default");
 
                 var apiUrl = $"https://cocoapods.org/pods/{packageName}";
                 var responseMessage = await httpClient.GetAsync(apiUrl);

--- a/SamplesDashboard/SamplesDashboard/Services/ManifestFromFileService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/ManifestFromFileService.cs
@@ -39,7 +39,7 @@ namespace SamplesDashboard.Services
             var fileType = GetSupportedFileType(dependencyFile);
             if (fileType != SupportedDependencyFileType.Unsupported)
             {
-                var httpClient = _clientFactory.CreateClient();
+                var httpClient = _clientFactory.CreateClient("Default");
                 var responseMessage = await httpClient.GetAsync(
                     $"https://raw.githubusercontent.com/microsoftgraph/{repoName}/{defaultBranch}/{dependencyFile}");
 

--- a/SamplesDashboard/SamplesDashboard/Services/MavenService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/MavenService.cs
@@ -39,7 +39,7 @@ namespace SamplesDashboard.Services
             var cacheKey = $"maven:{packageName}";
             if (!_cacheService.TryGetValue(cacheKey, out MavenQuery mavenData))
             {
-                var httpClient = _clientFactory.CreateClient();
+                var httpClient = _clientFactory.CreateClient("Default");
 
                 var packageParts = packageName.Split(':');
 
@@ -56,6 +56,10 @@ namespace SamplesDashboard.Services
                     {
                         mavenData = await JsonSerializer.DeserializeAsync<MavenQuery>(stream, _jsonOptions);
                     }
+                }
+                else
+                {
+                    var errorContent = await responseMessage.Content.ReadAsStringAsync();
                 }
 
                 if (mavenData != null)

--- a/SamplesDashboard/SamplesDashboard/Services/MicrosoftOpenSourceService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/MicrosoftOpenSourceService.cs
@@ -64,7 +64,7 @@ namespace SamplesDashboard.Services
                     throw new MsalException(MsalError.AuthenticationFailed, "AcquireTokenForClient returned null");
                 }
 
-                var client = _clientFactory.CreateClient();
+                var client = _clientFactory.CreateClient("Default");
 
                 var apiPath =
                     $"https://repos.opensource.microsoft.com/api/maintainers/org/{organization}/repo/{repoName}?api-version=2017-09-01";

--- a/SamplesDashboard/SamplesDashboard/Services/NpmService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/NpmService.cs
@@ -31,7 +31,7 @@ namespace SamplesDashboard.Services
             var cacheKey = $"npm:{packageName}";
             if (!_cacheService.TryGetValue(cacheKey, out string latestVersion))
             {
-                var httpClient = _clientFactory.CreateClient();
+                var httpClient = _clientFactory.CreateClient("Default");
 
                 var response = await httpClient.GetAsync($"{npmRegistry}{packageName}");
 

--- a/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
+++ b/SamplesDashboard/SamplesDashboard/Services/RepositoriesService.cs
@@ -490,7 +490,7 @@ namespace SamplesDashboard.Services
         {
             //downloading the yaml file
             var gitHubOrg = _configuration.GetValue<string>("GitHubOrg");
-            var httpClient = _clientFactory.CreateClient();
+            var httpClient = _clientFactory.CreateClient("Default");
             return await YamlHeader.GetFromRepo(httpClient, gitHubOrg, repoName, branch);
         }
 

--- a/SamplesDashboard/SamplesDashboard/Startup.cs
+++ b/SamplesDashboard/SamplesDashboard/Startup.cs
@@ -38,7 +38,13 @@ namespace SamplesDashboard
             services.AddControllersWithViews();
 
             services.AddMemoryCache();
-            services.AddHttpClient();
+            services.AddHttpClient("Default", cli => {
+                // Include user agent info
+                cli.DefaultRequestHeaders.UserAgent.Add(
+                    new ProductInfoHeaderValue(Configuration.GetValue<string>("Product"),
+                                            Configuration.GetValue<string>("ProductVersion"))
+                );
+            });
 
             // Add a GraphQL client
             services

--- a/SamplesDashboard/SamplesDashboardTests/SamplesDashboardTests.csproj
+++ b/SamplesDashboard/SamplesDashboardTests/SamplesDashboardTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspnetCore.Mvc.Testing" Version="5.0.11" />
+    <PackageReference Include="Microsoft.AspnetCore.Mvc.Testing" Version="5.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
## Description

Added `User-Agent` header to default `HttpClient` supplied by dependency injection. Requests to maven.org were returning `403` due to an empty `User-Agent` header.

**This was causing all test runs to fail**

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

