### PR TITLE
Add Accept header to the HttpRequestMessage

### DIFF
--- a/SamplesDashboard/SamplesDashboard/MessageHandlers/GitHubAuthHandler.cs
+++ b/SamplesDashboard/SamplesDashboard/MessageHandlers/GitHubAuthHandler.cs
@@ -34,6 +34,7 @@ namespace SamplesDashboard.MessageHandlers
         {
             var token = await _gitHubAuthService.GetGitHubAppToken();
             requestMessage.Headers.Authorization = new AuthenticationHeaderValue("bearer", token);
+            requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.hawkgirl-preview+json"));            
             return await base.SendAsync(requestMessage, cancellationToken);
         }
     }

--- a/SamplesDashboard/SamplesDashboard/Startup.cs
+++ b/SamplesDashboard/SamplesDashboard/Startup.cs
@@ -49,11 +49,6 @@ namespace SamplesDashboard
             // Add a GraphQL client
             services
                 .AddHttpClient<GraphQLHttpClient>(cli => {
-                    // Enable dependency graph info in GraphQL queries
-                    // https://docs.github.com/en/graphql/overview/schema-previews#access-to-a-repositories-dependency-graph-preview
-                    cli.DefaultRequestHeaders.Accept.Add(
-                        new MediaTypeWithQualityHeaderValue("application/vnd.github.hawkgirl-preview+json")
-                    );
                     // Include user agent info
                     cli.DefaultRequestHeaders.UserAgent.Add(
                         new ProductInfoHeaderValue(Configuration.GetValue<string>("Product"),


### PR DESCRIPTION
Allows us to set the `application/vnd.github.hawkgirl-preview+json` header to the HttpRequestMessage object in the Request handler for access to the `dependencyGraphManifest` object in a repository while calling the GitHub API

Reference:  https://github.com/microsoft/referencesource/blob/dae14279dd0672adead5de00ac8f117dcf74c184/System/net/System/Net/Http/Headers/HttpHeaders.cs#L565