### PR TITLE
Increase http timeout

### DIFF
--- a/SamplesDashboard/SamplesDashboard/Policies/GitHubRetryPolicy.cs
+++ b/SamplesDashboard/SamplesDashboard/Policies/GitHubRetryPolicy.cs
@@ -17,12 +17,12 @@ namespace SamplesDashboard.Policies
         {
             return HttpPolicyExtensions
               .HandleTransientHttpError()
-              .OrResult(msg => msg.StatusCode == HttpStatusCode.Forbidden)
+              .OrResult(msg => msg.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.InternalServerError)
               .WaitAndRetryAsync(6, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
         }
 
         /// <summary>
-        /// An HTTP retry policy to retry HTTP requests when we encounter HTTP 403 and 503,
+        /// An HTTP retry policy to retry HTTP requests when we encounter HTTP 403, 500 and 503,
         /// with exponential back-off
         /// Useful due to transient networking issues on the cloud.
         /// </summary>

--- a/SamplesDashboard/SamplesDashboard/Policies/GitHubRetryPolicy.cs
+++ b/SamplesDashboard/SamplesDashboard/Policies/GitHubRetryPolicy.cs
@@ -17,7 +17,7 @@ namespace SamplesDashboard.Policies
         {
             return HttpPolicyExtensions
               .HandleTransientHttpError()
-              .OrResult(msg => msg.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.InternalServerError)
+              .OrResult(msg => msg.StatusCode is HttpStatusCode.Forbidden)
               .WaitAndRetryAsync(6, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
         }
 

--- a/SamplesDashboard/SamplesDashboard/Startup.cs
+++ b/SamplesDashboard/SamplesDashboard/Startup.cs
@@ -44,6 +44,7 @@ namespace SamplesDashboard
                     new ProductInfoHeaderValue(Configuration.GetValue<string>("Product"),
                                             Configuration.GetValue<string>("ProductVersion"))
                 );
+                cli.Timeout = TimeSpan.FromSeconds(500);
             });
 
             // Add a GraphQL client
@@ -54,6 +55,7 @@ namespace SamplesDashboard
                         new ProductInfoHeaderValue(Configuration.GetValue<string>("Product"),
                                                 Configuration.GetValue<string>("ProductVersion"))
                     );
+                    cli.Timeout = TimeSpan.FromSeconds(500);
                 })
                 .AddPolicyHandler(GitHubRetryPolicy.Policy)
                 .AddHttpMessageHandler<GitHubAuthHandler>();


### PR DESCRIPTION
## Description
Currently, the API is returning an error 500 as a result of the `HttpClient` timing out when processing the requests to fetch repositories resulting to `TaskCanceledExceptions`.
The default HttpClient timeout is 100sec. Increasing this to 500secs will buy more time for tasks to run to completion.